### PR TITLE
Release desktop 0.1.6 with QQ Bot QR binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.1.5 - 2026-08-14
+
+中文：
+
+- 窗口标题栏现在跟随 DSH 的亮色/暗色主题，并让原生 Windows 窗口按钮同步使用匹配的前景与背景色。
+- 修复设置等全屏弹窗被自定义标题栏遮住上边界的问题，弹窗统一使用标题栏下方的安全可视区域。
+- 修复打包版皮肤中心扫描源码路径和写错配置层的问题；现在从 `~/.dsh/profiles/desktop/node_modules` 发现皮肤，并更新桌面 profile 的 `cordis.patch.yml`。
+- 将 `dshmarket` 1.0.3 与 `dsh-plugin-hub` 0.1.0 作为内置桌面插件，并让市场安装目标指向 `desktop` profile。
+
+English:
+
+- Made the custom title bar follow the DSH light/dark theme, including matching native Windows caption colors.
+- Kept full-screen dialogs below the custom title bar so their top border and rounded corners are no longer clipped.
+- Fixed packaged Skin Center discovery and configuration: skins are read from the desktop profile and switches update that profile's patch file.
+- Bundled `dshmarket` 1.0.3 and `dsh-plugin-hub` 0.1.0, with marketplace installs targeting the desktop profile.
+
 ## 0.1.4 - 2026-08-14
 
 中文：

--- a/apps/dsh-desktop/package.json
+++ b/apps/dsh-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-ai/dsh-desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "Lossless desktop shell for DeepSeek Harness and the complete dsh-web-ui plugin collection",
   "author": "DeepSeek Harness Desktop contributors",
@@ -11,6 +11,7 @@
     "dev": "electron src/main.mjs",
     "capture:startup": "node scripts/capture-startup.mjs",
     "capture:extensions": "node scripts/capture-startup.mjs --extensions",
+    "capture:qqbot": "node scripts/capture-startup.mjs --qqbot-qr",
     "test:window-chrome:e2e": "node scripts/verify-window-chrome.mjs",
     "test:directory-picker:e2e": "node scripts/verify-directory-picker.mjs",
     "test": "node --test test/*.test.mjs",
@@ -42,10 +43,13 @@
     "@deepseek-ai/dsh-timeout": "0.1.0-rc.6",
     "@deepseek-ai/dsh-workflow": "0.1.0-rc.6",
     "@linxin666/dsh-web-ui-all": "workspace:*",
+    "@tencent-connect/dsh-qqbot": "0.2.0",
+    "@tencent-connect/qqbot-connector": "1.2.0",
     "dsh-plugin-hub": "0.1.0",
     "dshmarket": "1.0.3",
     "electron-updater": "6.8.9",
     "pnpm": "11.21.0",
+    "qrcode": "1.5.4",
     "yaml": "2.8.1"
   },
   "devDependencies": {

--- a/apps/dsh-desktop/package.json
+++ b/apps/dsh-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-ai/dsh-desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Lossless desktop shell for DeepSeek Harness and the complete dsh-web-ui plugin collection",
   "author": "DeepSeek Harness Desktop contributors",
@@ -42,6 +42,8 @@
     "@deepseek-ai/dsh-timeout": "0.1.0-rc.6",
     "@deepseek-ai/dsh-workflow": "0.1.0-rc.6",
     "@linxin666/dsh-web-ui-all": "workspace:*",
+    "dsh-plugin-hub": "0.1.0",
+    "dshmarket": "1.0.3",
     "electron-updater": "6.8.9",
     "pnpm": "11.21.0",
     "yaml": "2.8.1"

--- a/apps/dsh-desktop/scripts/capture-startup.mjs
+++ b/apps/dsh-desktop/scripts/capture-startup.mjs
@@ -7,7 +7,8 @@ import electronPath from 'electron'
 import { _electron as electron } from 'playwright'
 
 const appDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const extensionMode = process.argv.includes('--extensions')
+const qqBotMode = process.argv.includes('--qqbot-qr')
+const extensionMode = process.argv.includes('--extensions') || qqBotMode
 const outputArgument = process.argv.find((argument) => argument.toLowerCase().endsWith('.png'))
 const output = resolve(outputArgument || (extensionMode ? 'extensions-preview.png' : 'startup-preview.png'))
 const temporary = await mkdtemp(resolve(tmpdir(), 'dsh-desktop-capture-'))
@@ -42,6 +43,10 @@ try {
   await page.waitForLoadState('domcontentloaded')
   if (extensionMode) {
     await page.waitForFunction(() => document.body.dataset.busy !== 'true' && document.querySelector('#plugin-count')?.textContent !== '0')
+    if (qqBotMode) {
+      await page.getByRole('button', { name: '扫码绑定 QQ 机器人' }).click()
+      await page.locator('#qqbot-qr[src^="data:image/png;base64,"]').waitFor({ state: 'visible', timeout: 20_000 })
+    }
   }
   await page.setViewportSize({ width: 1440, height: 900 })
   await page.screenshot({ path: output })

--- a/apps/dsh-desktop/scripts/verify-package.mjs
+++ b/apps/dsh-desktop/scripts/verify-package.mjs
@@ -20,6 +20,9 @@ const requiredPackages = [
   ...DSH_BOOT_RUNTIME_PACKAGES,
   'electron-updater',
   'pnpm',
+  '@tencent-connect/qqbot-connector',
+  '@tencent-connect/qqbot-nodejs',
+  'qrcode',
   ...MANAGED_RUNTIME_PACKAGES,
 ]
 

--- a/apps/dsh-desktop/scripts/verify-window-chrome.mjs
+++ b/apps/dsh-desktop/scripts/verify-window-chrome.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -27,8 +27,14 @@ try {
     },
   })
   const page = await electronApp.firstWindow()
+  page.on('pageerror', (error) => console.error(`renderer error: ${error.message}`))
   await page.waitForURL(/^http:\/\/127\.0\.0\.1:/u, { timeout: 60_000 })
-  await page.waitForSelector('#dsh-desktop-window-chrome')
+  try {
+    await page.waitForSelector('#dsh-desktop-window-chrome')
+  } catch (error) {
+    console.error(`window chrome missing at ${page.url()}: ${(await page.locator('body').innerText()).slice(0, 1_000)}`)
+    throw error
+  }
   const state = await page.evaluate(() => ({
     chromeCount: document.querySelectorAll('#dsh-desktop-window-chrome').length,
     context: document.querySelector('.dsh-window-chrome-context')?.textContent,
@@ -38,6 +44,31 @@ try {
   assert.equal(state.context, 'Web Surface')
   assert.equal(state.paddingTop, '46px')
   assert.equal(state.chromeCount, 1)
+  await page.evaluate(() => {
+    document.body.removeAttribute('data-ds-dark-theme')
+    document.documentElement.style.colorScheme = 'light'
+    document.body.style.backgroundColor = 'rgb(250, 250, 250)'
+  })
+  await page.waitForFunction(() => document.documentElement.dataset.dshDesktopChromeTheme === 'light')
+  assert.equal(await page.locator('.dsh-window-chrome-title').evaluate((element) => getComputedStyle(element).color), 'rgb(17, 24, 39)')
+  await page.evaluate(() => document.body.setAttribute('data-ds-dark-theme', ''))
+  await page.waitForFunction(() => document.documentElement.dataset.dshDesktopChromeTheme === 'dark')
+  const assertDialogUsesSafeViewport = async (dialog) => {
+    await dialog.waitFor({ state: 'visible' })
+    const state = await dialog.evaluate((element) => ({
+      layerClass: element.parentElement?.className,
+      layerTop: element.parentElement?.getBoundingClientRect().top,
+    }))
+    assert.match(String(state.layerClass), /dsh-desktop-modal-layer/u)
+    assert.ok(Number(state.layerTop) >= 45, `modal layer starts under the title bar: ${state.layerTop}`)
+  }
+  const introDialog = page.locator('[role="dialog"]').filter({ hasText: '内测声明' })
+  await assertDialogUsesSafeViewport(introDialog)
+  await page.getByRole('button', { name: '继续', exact: true }).click()
+  await introDialog.waitFor({ state: 'hidden' })
+  await page.locator('button').filter({ hasText: /^设置$/u }).first().evaluate((button) => button.click())
+  const settingsDialog = page.locator('[role="dialog"]').filter({ hasText: '插件市场' })
+  await assertDialogUsesSafeViewport(settingsDialog)
   const nativeWindowState = await electronApp.evaluate(({ app, BrowserWindow, Menu, nativeImage }) => {
     const window = BrowserWindow.getAllWindows()[0]
     const helpMenu = Menu.getApplicationMenu()?.items.find((item) => item.label.includes('Help'))
@@ -64,6 +95,9 @@ try {
     menuBarVisible: false,
     minimizable: true,
   })
+  const pnpmShim = await readFile(resolve(temporary, 'user-data', 'runtime-bin', 'pnpm.cmd'), 'utf8')
+  assert.match(pnpmShim, /ELECTRON_RUN_AS_NODE=1/u)
+  assert.match(pnpmShim, /pnpm\.(?:mjs|cjs)/u)
   if (screenshot) await page.screenshot({ path: screenshot })
   console.log(`verified runtime window chrome at ${state.url}`)
 } finally {

--- a/apps/dsh-desktop/src/electron-app.mjs
+++ b/apps/dsh-desktop/src/electron-app.mjs
@@ -1,19 +1,19 @@
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 
 import { applyWindowIcon, resolveAppIconPath } from './app-icon.mjs'
 import { BoundedLogStore } from './log-store.mjs'
 import { registerExtensionIpc } from './extension-ipc.mjs'
-import { PluginManager } from './extensions/plugins.mjs'
+import { PluginManager, resolvePnpmCliPath } from './extensions/plugins.mjs'
 import { registerDesktopIpc } from './ipc.mjs'
 import { installApplicationMenu } from './menu.mjs'
 import { installNavigationPolicy } from './navigation-policy.mjs'
 import { ensureDesktopProfile, resolveDshCliPath } from './profile.mjs'
 import { DshRuntimeController } from './runtime-controller.mjs'
 import { DesktopUpdateController, loadElectronAutoUpdater } from './updater.mjs'
-import { installWindowChrome, windowChromeBrowserOptions } from './window-chrome.mjs'
+import { installWindowChrome, setWindowChromeTheme, windowChromeBrowserOptions } from './window-chrome.mjs'
 import { attachWindowStatePersistence, loadWindowState } from './window-state.mjs'
 
 const SOURCE_DIR = dirname(fileURLToPath(import.meta.url))
@@ -28,6 +28,20 @@ function runtimeHome() {
 function runtimeWorkspace(app) {
   if (!app.isPackaged) return join(SOURCE_DIR, '..', '..', '..')
   return homedir()
+}
+
+export async function ensurePnpmCommandShim({ directory, executable, pnpmCli }) {
+  await mkdir(directory, { recursive: true })
+  const path = join(directory, process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm')
+  const content = process.platform === 'win32'
+    ? `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${executable}" "${pnpmCli}" %*\r\n`
+    : `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${executable}" "${pnpmCli}" "$@"\n`
+  const existing = await readFile(path, 'utf8').catch((error) => {
+    if (error?.code === 'ENOENT') return undefined
+    throw error
+  })
+  if (existing !== content) await writeFile(path, content, { encoding: 'utf8', mode: 0o755 })
+  return directory
 }
 
 export async function startElectronApp(metadata) {
@@ -59,6 +73,11 @@ export async function startElectronApp(metadata) {
   const ensureProfile = () => ensureDesktopProfile({ dshHome })
   const profile = await ensureProfile()
   const projectRoot = runtimeWorkspace(app)
+  const runtimeBin = await ensurePnpmCommandShim({
+    directory: join(userData, 'runtime-bin'),
+    executable: process.execPath,
+    pnpmCli: resolvePnpmCliPath(),
+  })
 
   const controller = new DshRuntimeController({
     cliPath: resolveDshCliPath(),
@@ -68,6 +87,7 @@ export async function startElectronApp(metadata) {
     logStore,
     autoRestart: true,
     startupTimeoutMs: 60_000,
+    pathEntries: [runtimeBin],
   })
 
   const statePath = join(userData, 'window-state.json')
@@ -127,6 +147,11 @@ export async function startElectronApp(metadata) {
     ensureProfile,
     openLogs: () => shell.openPath(logsDirectory),
     exitApp: () => app.quit(),
+    setWindowChromeTheme: (sender, theme) => {
+      const target = BrowserWindow.fromWebContents(sender)
+      if (!target || target.isDestroyed()) return undefined
+      return setWindowChromeTheme(target, theme)
+    },
   })
 
   const createExtensionWindow = async () => {

--- a/apps/dsh-desktop/src/electron-app.mjs
+++ b/apps/dsh-desktop/src/electron-app.mjs
@@ -3,10 +3,17 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 
+import { startQrConnect } from '@tencent-connect/qqbot-connector'
+
 import { applyWindowIcon, resolveAppIconPath } from './app-icon.mjs'
 import { BoundedLogStore } from './log-store.mjs'
 import { registerExtensionIpc } from './extension-ipc.mjs'
 import { PluginManager, resolvePnpmCliPath } from './extensions/plugins.mjs'
+import {
+  QqBotBindingService,
+  QqBotCredentialStore,
+  setQqBotProfileEnabled,
+} from './extensions/qqbot.mjs'
 import { registerDesktopIpc } from './ipc.mjs'
 import { installApplicationMenu } from './menu.mjs'
 import { installNavigationPolicy } from './navigation-policy.mjs'
@@ -46,7 +53,7 @@ export async function ensurePnpmCommandShim({ directory, executable, pnpmCli }) 
 
 export async function startElectronApp(metadata) {
   const electron = await import('electron')
-  const { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, screen, shell } = electron
+  const { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, safeStorage, screen, shell } = electron
   if (process.env.DSH_DESKTOP_USER_DATA) app.setPath('userData', process.env.DSH_DESKTOP_USER_DATA)
   if (!app.requestSingleInstanceLock()) {
     app.quit()
@@ -70,8 +77,26 @@ export async function startElectronApp(metadata) {
   await mkdir(logsDirectory, { recursive: true })
   const logStore = new BoundedLogStore({ directory: logsDirectory })
   const dshHome = runtimeHome()
-  const ensureProfile = () => ensureDesktopProfile({ dshHome })
-  const profile = await ensureProfile()
+  let qqBotCredentials
+  const ensureProfile = async () => {
+    const result = await ensureDesktopProfile({ dshHome })
+    await setQqBotProfileEnabled({ profileDir: result.profileDir, enabled: Boolean(qqBotCredentials) })
+    return result
+  }
+  const profile = await ensureDesktopProfile({ dshHome })
+  const qqBotCredentialStore = new QqBotCredentialStore({
+    path: join(userData, 'qqbot-credentials.json'),
+    safeStorage,
+  })
+  try {
+    qqBotCredentials = await qqBotCredentialStore.load()
+  } catch (error) {
+    await logStore.append(`[qqbot] failed to load credentials: ${error.message}`)
+  }
+  await setQqBotProfileEnabled({ profileDir: profile.profileDir, enabled: Boolean(qqBotCredentials) })
+  const qqBotEnvironment = () => qqBotCredentials
+    ? { QQBOT_APPID: qqBotCredentials.appId, QQBOT_SECRET: qqBotCredentials.appSecret }
+    : { QQBOT_APPID: '', QQBOT_SECRET: '' }
   const projectRoot = runtimeWorkspace(app)
   const runtimeBin = await ensurePnpmCommandShim({
     directory: join(userData, 'runtime-bin'),
@@ -88,6 +113,15 @@ export async function startElectronApp(metadata) {
     autoRestart: true,
     startupTimeoutMs: 60_000,
     pathEntries: [runtimeBin],
+    environmentProvider: qqBotEnvironment,
+  })
+  const qqBotBinding = new QqBotBindingService({
+    initialCredentials: qqBotCredentials,
+    credentialStore: qqBotCredentialStore,
+    startQrConnect,
+    setProfileEnabled: (enabled) => setQqBotProfileEnabled({ profileDir: profile.profileDir, enabled }),
+    setRuntimeCredentials: (credentials) => { qqBotCredentials = credentials },
+    restartRuntime: () => controller.restart(),
   })
 
   const statePath = join(userData, 'window-state.json')
@@ -214,6 +248,7 @@ export async function startElectronApp(metadata) {
     projectRoot,
     dshHome,
     agentsHome: process.env.DSH_AGENTS_HOME,
+    qqBotBinding,
   })
   const loadStartup = async () => {
     activeOrigin = undefined
@@ -267,6 +302,7 @@ export async function startElectronApp(metadata) {
         removeMainWindowChrome()
         unregisterIpc()
         unregisterExtensionIpc()
+        qqBotBinding.dispose()
       })
     return shutdownPromise
   }

--- a/apps/dsh-desktop/src/extension-ipc.mjs
+++ b/apps/dsh-desktop/src/extension-ipc.mjs
@@ -10,6 +10,10 @@ const CHANNELS = [
   'extensions:skill-import',
   'extensions:skill-open',
   'extensions:skill-root',
+  'extensions:qqbot-status',
+  'extensions:qqbot-bind',
+  'extensions:qqbot-cancel',
+  'extensions:qqbot-unbind',
 ]
 
 export function registerExtensionIpc({
@@ -23,6 +27,7 @@ export function registerExtensionIpc({
   projectRoot,
   dshHome,
   agentsHome,
+  qqBotBinding,
 }) {
   for (const channel of CHANNELS) ipcMain.removeHandler(channel)
   let skillPaths = new Map()
@@ -48,6 +53,7 @@ export function registerExtensionIpc({
     return {
       plugins,
       skills,
+      qqbot: qqBotBinding.status(),
       diagnostics: catalog.diagnostics.map((item) => ({ error: item.error })),
     }
   }
@@ -88,8 +94,20 @@ export function registerExtensionIpc({
     await mkdir(root, { recursive: true })
     return shell.openPath(root)
   })
+  ipcMain.handle('extensions:qqbot-status', () => qqBotBinding.status())
+  ipcMain.handle('extensions:qqbot-bind', () => qqBotBinding.start())
+  ipcMain.handle('extensions:qqbot-cancel', () => qqBotBinding.cancel())
+  ipcMain.handle('extensions:qqbot-unbind', () => qqBotBinding.unbind())
+
+  const forwardQqBotEvent = (payload) => {
+    const window = getWindow()
+    if (!window || window.isDestroyed?.()) return
+    window.webContents.send('extensions:qqbot-event', payload)
+  }
+  qqBotBinding.on('event', forwardQqBotEvent)
 
   return () => {
+    qqBotBinding.off('event', forwardQqBotEvent)
     for (const channel of CHANNELS) ipcMain.removeHandler(channel)
   }
 }

--- a/apps/dsh-desktop/src/extensions/qqbot.mjs
+++ b/apps/dsh-desktop/src/extensions/qqbot.mjs
@@ -1,0 +1,302 @@
+import { EventEmitter } from 'node:events'
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import qrcode from 'qrcode'
+
+export const QQBOT_PACKAGE = '@tencent-connect/dsh-qqbot'
+export const QQBOT_PATCH_START = '# --- dsh-desktop qqbot (auto-generated; do not edit) ---'
+export const QQBOT_PATCH_END = '# --- end dsh-desktop qqbot ---'
+
+function assertCredentials(credentials) {
+  if (
+    credentials === null
+    || typeof credentials !== 'object'
+    || typeof credentials.appId !== 'string'
+    || credentials.appId.trim().length === 0
+    || typeof credentials.appSecret !== 'string'
+    || credentials.appSecret.length === 0
+  ) {
+    throw new TypeError('QQ Bot credentials are invalid')
+  }
+  return { appId: credentials.appId.trim(), appSecret: credentials.appSecret }
+}
+
+async function atomicWrite(path, content, options = {}) {
+  await mkdir(dirname(path), { recursive: true })
+  const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const temporary = `${path}.tmp-${suffix}`
+  const backup = `${path}.bak-${suffix}`
+  await writeFile(temporary, content, { encoding: 'utf8', mode: 0o600, flag: 'wx', ...options })
+  let movedExisting = false
+  try {
+    try {
+      await rename(path, backup)
+      movedExisting = true
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error
+    }
+    await rename(temporary, path)
+    if (movedExisting) await rm(backup, { force: true })
+  } catch (error) {
+    await rm(temporary, { force: true })
+    if (movedExisting) {
+      await rm(path, { force: true })
+      await rename(backup, path)
+    }
+    throw error
+  }
+}
+
+export function qqBotPatchSection(enabled) {
+  return `${QQBOT_PATCH_START}\n- id: im-qqbot\n  disabled: ${enabled ? 'false' : 'true'}\n${QQBOT_PATCH_END}\n`
+}
+
+export function mergeQqBotPatch(existing = '', enabled = false) {
+  let remainder = String(existing)
+  const start = remainder.indexOf(QQBOT_PATCH_START)
+  if (start !== -1) {
+    const end = remainder.indexOf(QQBOT_PATCH_END, start)
+    if (end === -1) throw new Error('QQ Bot managed patch section is unterminated')
+    const before = remainder.slice(0, start).trimEnd()
+    const after = remainder.slice(end + QQBOT_PATCH_END.length).trimStart()
+    remainder = [before, after].filter(Boolean).join('\n\n')
+  }
+  const prefix = remainder.trim()
+  return prefix ? `${prefix}\n\n${qqBotPatchSection(enabled)}` : qqBotPatchSection(enabled)
+}
+
+export function readQqBotPatchEnabled(content = '') {
+  const start = String(content).indexOf(QQBOT_PATCH_START)
+  if (start === -1) return undefined
+  const end = String(content).indexOf(QQBOT_PATCH_END, start)
+  if (end === -1) throw new Error('QQ Bot managed patch section is unterminated')
+  const section = String(content).slice(start, end)
+  const match = /^[ \t]*disabled:[ \t]*(true|false)[ \t]*$/mu.exec(section)
+  if (!match) throw new Error('QQ Bot managed patch section has no disabled state')
+  return match[1] === 'false'
+}
+
+export async function setQqBotProfileEnabled({ profileDir, enabled }) {
+  if (typeof profileDir !== 'string' || profileDir.length === 0) {
+    throw new TypeError('profileDir is required')
+  }
+  const patchPath = join(profileDir, 'cordis.patch.yml')
+  const existing = await readFile(patchPath, 'utf8').catch((error) => {
+    if (error?.code === 'ENOENT') return ''
+    throw error
+  })
+  const next = mergeQqBotPatch(existing, Boolean(enabled))
+  if (next === existing) return false
+  await atomicWrite(patchPath, next)
+  return true
+}
+
+export function maskAppId(appId) {
+  const value = String(appId)
+  if (value.length <= 4) return '*'.repeat(value.length)
+  return `${value.slice(0, 2)}${'*'.repeat(Math.min(8, value.length - 4))}${value.slice(-2)}`
+}
+
+export class QqBotCredentialStore {
+  constructor({ path, safeStorage }) {
+    if (typeof path !== 'string' || path.length === 0) throw new TypeError('credential path is required')
+    if (!safeStorage) throw new TypeError('safeStorage is required')
+    this.path = path
+    this.safeStorage = safeStorage
+  }
+
+  async load() {
+    const content = await readFile(this.path, 'utf8').catch((error) => {
+      if (error?.code === 'ENOENT') return undefined
+      throw error
+    })
+    if (content === undefined) return undefined
+    if (!this.safeStorage.isEncryptionAvailable()) {
+      throw new Error('operating-system credential encryption is unavailable')
+    }
+    let envelope
+    try {
+      envelope = JSON.parse(content)
+      if (envelope.version !== 1 || typeof envelope.payload !== 'string') throw new Error('unsupported envelope')
+      const plaintext = this.safeStorage.decryptString(Buffer.from(envelope.payload, 'base64'))
+      return assertCredentials(JSON.parse(plaintext))
+    } catch (error) {
+      throw new Error(`QQ Bot credential store is invalid: ${error.message}`)
+    }
+  }
+
+  async save(credentials) {
+    const normalized = assertCredentials(credentials)
+    if (!this.safeStorage.isEncryptionAvailable()) {
+      throw new Error('operating-system credential encryption is unavailable')
+    }
+    const encrypted = this.safeStorage.encryptString(JSON.stringify(normalized))
+    const envelope = `${JSON.stringify({ version: 1, payload: encrypted.toString('base64') }, null, 2)}\n`
+    await atomicWrite(this.path, envelope)
+  }
+
+  async clear() {
+    await rm(this.path, { force: true })
+  }
+}
+
+export function createQrDataUrl(url) {
+  return qrcode.toDataURL(url, {
+    errorCorrectionLevel: 'M',
+    margin: 2,
+    width: 360,
+    color: { dark: '#061017ff', light: '#ffffffff' },
+  })
+}
+
+export class QqBotBindingService extends EventEmitter {
+  constructor({
+    initialCredentials,
+    credentialStore,
+    startQrConnect,
+    renderQr = createQrDataUrl,
+    setProfileEnabled,
+    setRuntimeCredentials,
+    restartRuntime,
+  }) {
+    super()
+    if (!credentialStore || typeof startQrConnect !== 'function') {
+      throw new TypeError('credentialStore and startQrConnect are required')
+    }
+    this.credentials = initialCredentials ? assertCredentials(initialCredentials) : undefined
+    this.credentialStore = credentialStore
+    this.startQrConnect = startQrConnect
+    this.renderQr = renderQr
+    this.setProfileEnabled = setProfileEnabled
+    this.setRuntimeCredentials = setRuntimeCredentials
+    this.restartRuntime = restartRuntime
+    this.binding = false
+    this.settling = false
+    this.qrImage = undefined
+    this.stopQr = undefined
+    this.operationPromise = undefined
+    this.generation = 0
+  }
+
+  status() {
+    return Object.freeze({
+      bound: Boolean(this.credentials),
+      binding: this.binding,
+      pending: this.settling,
+      appId: this.credentials ? maskAppId(this.credentials.appId) : undefined,
+      qrImage: this.qrImage,
+    })
+  }
+
+  #publish(type, details = {}) {
+    this.emit('event', Object.freeze({ type, ...details, status: this.status() }))
+  }
+
+  start() {
+    if (this.credentials || this.binding || this.settling) return this.status()
+    this.binding = true
+    this.qrImage = undefined
+    const generation = ++this.generation
+    const current = () => this.binding && generation === this.generation
+    try {
+      this.stopQr = this.startQrConnect({
+        onQrDisplayed: (url) => {
+          void Promise.resolve(this.renderQr(url)).then((image) => {
+            if (!current()) return
+            this.qrImage = image
+            this.#publish('qr')
+          }).catch((error) => {
+            if (current()) this.#fail(error)
+          })
+        },
+        onQrExpired: () => {
+          if (!current()) return
+          this.qrImage = undefined
+          this.#publish('refreshing')
+        },
+        onSuccess: (credentials) => {
+          if (!current()) return
+          this.binding = false
+          this.settling = true
+          this.qrImage = undefined
+          this.stopQr = undefined
+          this.#publish('saving')
+          this.operationPromise = this.#complete(credentials?.[0], generation)
+        },
+        onFailure: (error) => {
+          if (current()) this.#fail(error)
+        },
+      }, {
+        displayQrCodeToConsole: false,
+        source: 'dsh-desktop',
+      })
+      this.#publish('waiting')
+    } catch (error) {
+      this.#fail(error)
+    }
+    return this.status()
+  }
+
+  async #complete(credentials, generation) {
+    try {
+      const normalized = assertCredentials(credentials)
+      await this.credentialStore.save(normalized)
+      await this.setProfileEnabled(true)
+      this.setRuntimeCredentials(normalized)
+      if (generation !== this.generation) return
+      this.credentials = normalized
+      this.#publish('restarting')
+      await this.restartRuntime()
+      if (generation === this.generation) {
+        this.settling = false
+        this.operationPromise = undefined
+        this.#publish('bound')
+      }
+    } catch (error) {
+      if (generation === this.generation) this.#fail(error)
+    }
+  }
+
+  #fail(error) {
+    const stop = this.stopQr
+    this.binding = false
+    this.settling = false
+    this.qrImage = undefined
+    this.stopQr = undefined
+    this.operationPromise = undefined
+    this.generation += 1
+    stop?.()
+    this.#publish('error', { error: error instanceof Error ? error.message : String(error) })
+  }
+
+  cancel() {
+    if (!this.binding) return this.status()
+    const stop = this.stopQr
+    this.binding = false
+    this.qrImage = undefined
+    this.stopQr = undefined
+    this.generation += 1
+    stop?.()
+    this.#publish('canceled')
+    return this.status()
+  }
+
+  async unbind() {
+    await this.operationPromise?.catch(() => {})
+    this.cancel()
+    await this.credentialStore.clear()
+    await this.setProfileEnabled(false)
+    this.setRuntimeCredentials(undefined)
+    this.credentials = undefined
+    this.#publish('restarting')
+    await this.restartRuntime()
+    this.#publish('unbound')
+    return this.status()
+  }
+
+  dispose() {
+    this.cancel()
+    this.removeAllListeners()
+  }
+}

--- a/apps/dsh-desktop/src/ipc.mjs
+++ b/apps/dsh-desktop/src/ipc.mjs
@@ -1,4 +1,12 @@
 const ACTIONS = new Set(['retry', 'repair', 'open-logs', 'exit'])
+const WINDOW_CHROME_THEMES = new Set(['light', 'dark'])
+
+export function normalizeWindowChromeTheme(value) {
+  if (typeof value !== 'string' || !WINDOW_CHROME_THEMES.has(value)) {
+    throw new TypeError(`invalid window chrome theme: ${JSON.stringify(value)}`)
+  }
+  return value
+}
 
 export function normalizeDesktopAction(value) {
   if (typeof value !== 'string' || !ACTIONS.has(value)) {
@@ -27,8 +35,10 @@ export function registerDesktopIpc({
   ensureProfile,
   openLogs,
   exitApp,
+  setWindowChromeTheme,
 }) {
-  for (const channel of ['desktop:info', 'desktop:status', 'desktop:action']) ipcMain.removeHandler(channel)
+  const channels = ['desktop:info', 'desktop:status', 'desktop:action', 'desktop:window-chrome-theme']
+  for (const channel of channels) ipcMain.removeHandler(channel)
   ipcMain.handle('desktop:info', () => ({
     appId: metadata.appId,
     productName: metadata.productName,
@@ -48,10 +58,17 @@ export function registerDesktopIpc({
     exitApp()
     return undefined
   })
+  ipcMain.handle('desktop:window-chrome-theme', (event, rawTheme) => {
+    const theme = normalizeWindowChromeTheme(rawTheme)
+    return setWindowChromeTheme?.(event.sender, theme)
+  })
   const publishStatus = (status) => {
     const window = getWindow()
     if (window && !window.isDestroyed()) window.webContents.send('desktop:status', publicRuntimeStatus(status))
   }
   controller.on('status', publishStatus)
-  return () => controller.off('status', publishStatus)
+  return () => {
+    controller.off('status', publishStatus)
+    for (const channel of channels) ipcMain.removeHandler(channel)
+  }
 }

--- a/apps/dsh-desktop/src/log-store.mjs
+++ b/apps/dsh-desktop/src/log-store.mjs
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-const SECRET_ASSIGNMENT = /\b(NPM_TOKEN|DEEPSEEK_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|ACCESS_TOKEN|AUTH_TOKEN)=([^\s]+)/gi
+const SECRET_ASSIGNMENT = /\b(NPM_TOKEN|DEEPSEEK_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|QQBOT_SECRET|APP_SECRET|APPSECRET|API_KEY|ACCESS_TOKEN|AUTH_TOKEN)=([^\s]+)/gi
 const BEARER_TOKEN = /(Authorization:\s*Bearer\s+)([^\s]+)/gi
 
 export function sanitizeLogLine(value) {

--- a/apps/dsh-desktop/src/preload.cjs
+++ b/apps/dsh-desktop/src/preload.cjs
@@ -4,6 +4,7 @@ const api = Object.freeze({
   getInfo: () => ipcRenderer.invoke('desktop:info'),
   getStatus: () => ipcRenderer.invoke('desktop:status'),
   action: (action) => ipcRenderer.invoke('desktop:action', action),
+  setWindowChromeTheme: (theme) => ipcRenderer.invoke('desktop:window-chrome-theme', theme),
   listExtensions: () => ipcRenderer.invoke('extensions:list'),
   installPlugin: (spec) => ipcRenderer.invoke('extensions:plugin-install', spec),
   removePlugin: (name) => ipcRenderer.invoke('extensions:plugin-remove', name),

--- a/apps/dsh-desktop/src/preload.cjs
+++ b/apps/dsh-desktop/src/preload.cjs
@@ -11,6 +11,16 @@ const api = Object.freeze({
   importSkill: () => ipcRenderer.invoke('extensions:skill-import'),
   openSkill: (id) => ipcRenderer.invoke('extensions:skill-open', id),
   openSkillRoot: () => ipcRenderer.invoke('extensions:skill-root'),
+  getQqBotStatus: () => ipcRenderer.invoke('extensions:qqbot-status'),
+  startQqBotBinding: () => ipcRenderer.invoke('extensions:qqbot-bind'),
+  cancelQqBotBinding: () => ipcRenderer.invoke('extensions:qqbot-cancel'),
+  unbindQqBot: () => ipcRenderer.invoke('extensions:qqbot-unbind'),
+  onQqBotEvent(callback) {
+    if (typeof callback !== 'function') throw new TypeError('QQ Bot callback must be a function')
+    const listener = (_event, payload) => callback(payload)
+    ipcRenderer.on('extensions:qqbot-event', listener)
+    return () => ipcRenderer.removeListener('extensions:qqbot-event', listener)
+  },
   onStatus(callback) {
     if (typeof callback !== 'function') throw new TypeError('status callback must be a function')
     const listener = (_event, status) => callback(status)

--- a/apps/dsh-desktop/src/profile.mjs
+++ b/apps/dsh-desktop/src/profile.mjs
@@ -17,6 +17,8 @@ export const BUILTIN_BUNDLES = Object.freeze([
   '@deepseek-ai/dsh-base',
   '@deepseek-ai/dsh-web-app',
   '@linxin666/dsh-web-ui-all',
+  'dshmarket',
+  'dsh-plugin-hub',
 ])
 
 export const BUILTIN_SKIN_PACKAGES = Object.freeze([
@@ -53,6 +55,8 @@ export const BUILTIN_RUNTIME_PACKAGES = Object.freeze([
   '@linxin666/dsh-ssh',
   '@linxin666/dsh-web-ui-all',
   '@linxin666/dsh-web-ui-compat',
+  'dshmarket',
+  'dsh-plugin-hub',
 ].toSorted())
 
 export const DESKTOP_SUPPORT_PACKAGES = Object.freeze([
@@ -91,7 +95,9 @@ export const DSH_BOOT_RUNTIME_PACKAGES = Object.freeze([
 
 const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/
 const ROOT_CONFIG = '[]\n'
-export const DESKTOP_PATCH_CONFIG = `- id: directory-picker
+export const DESKTOP_PATCH_START = '# --- dsh-desktop managed (auto-generated; do not edit) ---'
+export const DESKTOP_PATCH_END = '# --- end dsh-desktop managed ---'
+const LEGACY_DESKTOP_PATCH_CONFIG = `- id: directory-picker
   name: '@deepseek-ai/dsh-host-directory-picker-auto'
   disabled: true
 - insert:
@@ -99,6 +105,13 @@ export const DESKTOP_PATCH_CONFIG = `- id: directory-picker
       name: '@deepseek-ai/dsh-host-directory-picker-browse'
     - id: directory-picker-desktop-client
       name: '@deepseek-ai/dsh-client-ui-directory-picker-browse'
+`
+export const DESKTOP_PATCH_CONFIG = `${DESKTOP_PATCH_START}
+${LEGACY_DESKTOP_PATCH_CONFIG.trimEnd()}
+- id: dsh-market
+  config:
+    profile: desktop
+${DESKTOP_PATCH_END}
 `
 const WORKSPACE_CONFIG = `packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n`
 
@@ -129,6 +142,20 @@ export function createDesktopProfileManifest(existing = {}) {
       },
     },
   }
+}
+
+export function mergeDesktopPatch(existing = '') {
+  let userPatch = String(existing)
+  const start = userPatch.indexOf(DESKTOP_PATCH_START)
+  if (start !== -1) {
+    const end = userPatch.indexOf(DESKTOP_PATCH_END, start)
+    if (end === -1) throw new Error('desktop managed patch section is unterminated')
+    userPatch = `${userPatch.slice(0, start)}${userPatch.slice(end + DESKTOP_PATCH_END.length)}`
+  } else if (userPatch.startsWith(LEGACY_DESKTOP_PATCH_CONFIG)) {
+    userPatch = userPatch.slice(LEGACY_DESKTOP_PATCH_CONFIG.length)
+  }
+  const suffix = userPatch.trim()
+  return suffix ? `${DESKTOP_PATCH_CONFIG.trimEnd()}\n\n${suffix}\n` : DESKTOP_PATCH_CONFIG
 }
 
 async function readJsonIfPresent(path) {
@@ -238,7 +265,12 @@ export async function ensureDesktopProfile({
 
   let changed = false
   changed = (await writeIfChanged(join(profileDir, 'cordis.yml'), ROOT_CONFIG)) || changed
-  changed = (await writeIfChanged(join(profileDir, 'cordis.patch.yml'), DESKTOP_PATCH_CONFIG)) || changed
+  const patchPath = join(profileDir, 'cordis.patch.yml')
+  const existingPatch = await readFile(patchPath, 'utf8').catch((error) => {
+    if (error?.code === 'ENOENT') return ''
+    throw error
+  })
+  changed = (await writeIfChanged(patchPath, mergeDesktopPatch(existingPatch))) || changed
   changed = (await writeIfChanged(join(profileDir, 'pnpm-workspace.yaml'), WORKSPACE_CONFIG)) || changed
   changed = (await writeIfChanged(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)) || changed
 

--- a/apps/dsh-desktop/src/profile.mjs
+++ b/apps/dsh-desktop/src/profile.mjs
@@ -12,11 +12,15 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mergeQqBotPatch, readQqBotPatchEnabled } from './extensions/qqbot.mjs'
 
 export const BUILTIN_BUNDLES = Object.freeze([
   '@deepseek-ai/dsh-base',
   '@deepseek-ai/dsh-web-app',
   '@linxin666/dsh-web-ui-all',
+  '@tencent-connect/dsh-qqbot',
   'dshmarket',
   'dsh-plugin-hub',
 ])
@@ -55,6 +59,7 @@ export const BUILTIN_RUNTIME_PACKAGES = Object.freeze([
   '@linxin666/dsh-ssh',
   '@linxin666/dsh-web-ui-all',
   '@linxin666/dsh-web-ui-compat',
+  '@tencent-connect/dsh-qqbot',
   'dshmarket',
   'dsh-plugin-hub',
 ].toSorted())
@@ -270,7 +275,9 @@ export async function ensureDesktopProfile({
     if (error?.code === 'ENOENT') return ''
     throw error
   })
-  changed = (await writeIfChanged(patchPath, mergeDesktopPatch(existingPatch))) || changed
+  const qqBotEnabled = readQqBotPatchEnabled(existingPatch) ?? false
+  const managedPatch = mergeQqBotPatch(mergeDesktopPatch(existingPatch), qqBotEnabled)
+  changed = (await writeIfChanged(patchPath, managedPatch)) || changed
   changed = (await writeIfChanged(join(profileDir, 'pnpm-workspace.yaml'), WORKSPACE_CONFIG)) || changed
   changed = (await writeIfChanged(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)) || changed
 
@@ -311,6 +318,22 @@ function resolvePackageRoot(packageName, anchors) {
       }
     } catch {
       // Try the next anchor.
+    }
+    let cursor
+    try {
+      const anchorPath = String(anchor).startsWith('file:') ? fileURLToPath(anchor) : String(anchor)
+      cursor = dirname(anchorPath)
+    } catch {
+      cursor = undefined
+    }
+    while (cursor) {
+      const candidate = join(cursor, 'node_modules', ...packagePathSegments(packageName))
+      if (readJsonSync(join(candidate, 'package.json'))?.name === packageName) {
+        return materializeFilesystemPath(candidate)
+      }
+      const parent = dirname(cursor)
+      if (parent === cursor) break
+      cursor = parent
     }
   }
   return undefined

--- a/apps/dsh-desktop/src/runtime-controller.mjs
+++ b/apps/dsh-desktop/src/runtime-controller.mjs
@@ -81,6 +81,7 @@ export class DshRuntimeController extends EventEmitter {
     schedule = setTimeout,
     cancelSchedule = clearTimeout,
     pathEntries = [],
+    environmentProvider = () => ({}),
   }) {
     super()
     if (!cliPath || !cwd || !dshHome) throw new TypeError('cliPath, cwd, and dshHome are required')
@@ -97,6 +98,8 @@ export class DshRuntimeController extends EventEmitter {
     this.schedule = schedule
     this.cancelSchedule = cancelSchedule
     this.pathEntries = pathEntries
+    if (typeof environmentProvider !== 'function') throw new TypeError('environmentProvider must be a function')
+    this.environmentProvider = environmentProvider
     this.child = undefined
     this.readyPromise = undefined
     this.restartTimer = undefined
@@ -130,8 +133,15 @@ export class DshRuntimeController extends EventEmitter {
     })
     this.readyPromise = readyPromise
 
+    const additionalEnvironment = this.environmentProvider() ?? {}
+    if (typeof additionalEnvironment !== 'object' || Array.isArray(additionalEnvironment)) {
+      const error = new TypeError('runtime environment provider must return an object')
+      this.#failBeforeReady(error)
+      return readyPromise
+    }
     const environment = {
       ...process.env,
+      ...additionalEnvironment,
       DSH_HOME: this.dshHome,
       DSH_PROFILE: 'desktop',
       DSH_SKIN_PROFILE: 'desktop',

--- a/apps/dsh-desktop/src/runtime-controller.mjs
+++ b/apps/dsh-desktop/src/runtime-controller.mjs
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
+import { delimiter } from 'node:path'
 
 const READY_LINE = /^dsh web:\s+(http:\/\/\S+)/u
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]', '::1'])
@@ -79,6 +80,7 @@ export class DshRuntimeController extends EventEmitter {
     probeReady = probeHttpReady,
     schedule = setTimeout,
     cancelSchedule = clearTimeout,
+    pathEntries = [],
   }) {
     super()
     if (!cliPath || !cwd || !dshHome) throw new TypeError('cliPath, cwd, and dshHome are required')
@@ -94,6 +96,7 @@ export class DshRuntimeController extends EventEmitter {
     this.probeReady = probeReady
     this.schedule = schedule
     this.cancelSchedule = cancelSchedule
+    this.pathEntries = pathEntries
     this.child = undefined
     this.readyPromise = undefined
     this.restartTimer = undefined
@@ -130,7 +133,10 @@ export class DshRuntimeController extends EventEmitter {
     const environment = {
       ...process.env,
       DSH_HOME: this.dshHome,
+      DSH_PROFILE: 'desktop',
+      DSH_SKIN_PROFILE: 'desktop',
       ELECTRON_RUN_AS_NODE: '1',
+      PATH: [...this.pathEntries, process.env.PATH].filter(Boolean).join(delimiter),
     }
     try {
       this.child = this.spawnProcess(

--- a/apps/dsh-desktop/src/ui/extensions.css
+++ b/apps/dsh-desktop/src/ui/extensions.css
@@ -47,6 +47,24 @@ main { position: relative; padding: 46px 56px 80px; }
 h2 { margin: 0; font-size: 30px; font-weight: 500; letter-spacing: -0.025em; }
 
 form, .skill-actions { margin-bottom: 26px; padding: 22px; border: 1px solid var(--line); background: var(--surface); }
+[hidden] { display: none !important; }
+.qqbot-card { margin-bottom: 26px; border: 1px solid rgba(102, 221, 245, 0.28); background: linear-gradient(135deg, rgba(102, 221, 245, 0.07), transparent 55%), var(--surface); }
+.qqbot-summary { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 24px; align-items: center; padding: 20px 22px; border-bottom: 1px solid var(--line); }
+.qqbot-state { display: flex; align-items: center; gap: 8px; color: var(--muted); font: 10px "Bahnschrift", sans-serif; letter-spacing: 0.08em; text-transform: uppercase; }
+.state-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); box-shadow: 0 0 0 4px rgba(137, 167, 179, 0.08); }
+.qqbot-card[data-state="binding"] .state-dot { background: var(--amber); box-shadow: 0 0 0 4px rgba(255, 193, 107, 0.1); animation: state-pulse 1.4s ease-in-out infinite; }
+.qqbot-card[data-state="bound"] .state-dot { background: var(--cyan); box-shadow: 0 0 0 4px rgba(102, 221, 245, 0.1); }
+.qqbot-card[data-state="error"] .state-dot { background: #ff8c70; }
+.qqbot-body { padding: 22px; }
+.qqbot-copy { max-width: 720px; margin: 0 0 18px; color: var(--muted); font-size: 12px; line-height: 1.7; }
+.qqbot-scan { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: 28px; align-items: center; }
+.qr-frame { display: grid; place-items: center; width: 220px; height: 220px; border: 1px solid var(--line); background: white; }
+.qr-frame img { width: 100%; height: 100%; object-fit: contain; }
+.qr-frame div { color: #33515e; font: 11px "Cascadia Mono", Consolas, monospace; }
+.qqbot-bound { display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+.qqbot-bound > div { display: grid; gap: 7px; }
+.qqbot-bound strong { font: 600 15px "Cascadia Mono", Consolas, monospace; letter-spacing: 0.08em; }
+@keyframes state-pulse { 50% { opacity: 0.4; } }
 label { display: block; margin-bottom: 12px; color: var(--muted); font-size: 9px; }
 .field-row { display: flex; gap: 10px; }
 input { flex: 1; min-width: 0; height: 44px; padding: 0 14px; border: 1px solid var(--line); outline: none; color: var(--ink); background: #061016; font: 13px "Cascadia Mono", Consolas, monospace; }
@@ -81,4 +99,5 @@ button.secondary { color: var(--muted); border-color: var(--line); background: t
   header, main { padding-left: 24px; padding-right: 24px; }
   nav { padding: 0 24px; }
   .panel-head { gap: 16px; }
+  .qqbot-summary, .qqbot-scan { grid-template-columns: 1fr; }
 }

--- a/apps/dsh-desktop/src/ui/extensions.html
+++ b/apps/dsh-desktop/src/ui/extensions.html
@@ -29,6 +29,35 @@
           <div><p class="index">01</p><h2 id="plugin-heading">Cordis 插件</h2></div>
           <p>安装注册表中的 DSH bundle。安装前请确认来源可信；插件拥有宿主进程权限。</p>
         </div>
+        <article class="qqbot-card" id="qqbot-card" data-state="unbound">
+          <div class="qqbot-summary">
+            <div>
+              <div class="name-row">
+                <span class="name">QQ 机器人</span>
+                <span class="badge builtin">OFFICIAL / BUILT-IN</span>
+              </div>
+              <p class="description">通过腾讯官方 dsh-qqbot 将 QQ 私聊和群聊接入 desktop profile。</p>
+            </div>
+            <div class="qqbot-state"><span class="state-dot"></span><span id="qqbot-state-label">读取状态</span></div>
+          </div>
+          <div class="qqbot-body">
+            <div id="qqbot-unbound">
+              <p class="qqbot-copy">绑定过程会显示一次性二维码。AppSecret 由操作系统加密保存，不会显示在页面或写入 profile 配置。</p>
+              <button type="button" id="qqbot-bind">扫码绑定 QQ 机器人</button>
+            </div>
+            <div class="qqbot-scan" id="qqbot-scan" hidden>
+              <div class="qr-frame"><img id="qqbot-qr" alt="QQ 机器人绑定二维码" hidden><div id="qqbot-qr-wait">正在获取二维码</div></div>
+              <div>
+                <p class="qqbot-copy">请使用手机 QQ 扫描二维码完成机器人绑定。二维码过期后会自动刷新。</p>
+                <button type="button" class="secondary" id="qqbot-cancel">取消绑定</button>
+              </div>
+            </div>
+            <div class="qqbot-bound" id="qqbot-bound" hidden>
+              <div><span class="meta">APP ID</span><strong id="qqbot-appid">--</strong></div>
+              <button type="button" class="item-action danger" id="qqbot-unbind">解除绑定</button>
+            </div>
+          </div>
+        </article>
         <form id="plugin-form">
           <label for="plugin-spec">NPM PACKAGE SPEC</label>
           <div class="field-row">

--- a/apps/dsh-desktop/src/ui/extensions.mjs
+++ b/apps/dsh-desktop/src/ui/extensions.mjs
@@ -3,6 +3,14 @@ const skillList = document.querySelector('#skill-list')
 const pluginCount = document.querySelector('#plugin-count')
 const skillCount = document.querySelector('#skill-count')
 const toast = document.querySelector('#toast')
+const qqBotCard = document.querySelector('#qqbot-card')
+const qqBotStateLabel = document.querySelector('#qqbot-state-label')
+const qqBotUnbound = document.querySelector('#qqbot-unbound')
+const qqBotScan = document.querySelector('#qqbot-scan')
+const qqBotBound = document.querySelector('#qqbot-bound')
+const qqBotQr = document.querySelector('#qqbot-qr')
+const qqBotQrWait = document.querySelector('#qqbot-qr-wait')
+const qqBotAppId = document.querySelector('#qqbot-appid')
 
 function escapeHtml(value) {
   const element = document.createElement('span')
@@ -32,12 +40,33 @@ function skillMarkup(skill) {
   return `<article class="item"><div><div class="name-row"><span class="name">${escapeHtml(skill.name)}</span>${shadow}</div><p class="description">${escapeHtml(skill.description)}</p></div><button type="button" class="item-action" data-open-skill="${escapeHtml(skill.id)}">${escapeHtml(skill.source)}</button></article>`
 }
 
+function renderQqBot(status, eventType) {
+  const bound = Boolean(status?.bound)
+  const binding = Boolean(status?.binding)
+  const pending = Boolean(status?.pending) || eventType === 'saving' || eventType === 'restarting'
+  qqBotUnbound.hidden = bound || binding || pending
+  qqBotScan.hidden = !binding
+  qqBotBound.hidden = !bound
+  qqBotCard.dataset.state = eventType === 'error' ? 'error' : bound ? 'bound' : binding || pending ? 'binding' : 'unbound'
+  qqBotStateLabel.textContent = bound
+    ? (eventType === 'restarting' ? '正在重启' : '已绑定')
+    : binding
+      ? (status.qrImage ? '等待扫码' : '获取二维码')
+      : eventType === 'saving' ? '正在保存' : eventType === 'restarting' ? '正在重启' : eventType === 'error' ? '绑定失败' : '未绑定'
+  qqBotAppId.textContent = status?.appId ?? '--'
+  qqBotQr.hidden = !status?.qrImage
+  qqBotQrWait.hidden = Boolean(status?.qrImage)
+  if (status?.qrImage) qqBotQr.src = status.qrImage
+  else qqBotQr.removeAttribute('src')
+}
+
 async function refresh() {
   document.body.dataset.busy = 'true'
   try {
     const inventory = await window.dshDesktop.listExtensions()
     pluginCount.textContent = inventory.plugins.length
     skillCount.textContent = inventory.skills.length
+    renderQqBot(inventory.qqbot)
     pluginList.innerHTML = inventory.plugins.length ? inventory.plugins.map(pluginMarkup).join('') : '<p class="empty">暂无插件</p>'
     skillList.innerHTML = inventory.skills.length ? inventory.skills.map(skillMarkup).join('') : '<p class="empty">尚未发现技能</p>'
   } catch (error) {
@@ -46,6 +75,49 @@ async function refresh() {
     delete document.body.dataset.busy
   }
 }
+
+document.querySelector('#qqbot-bind').addEventListener('click', async (event) => {
+  event.currentTarget.disabled = true
+  try {
+    renderQqBot(await window.dshDesktop.startQqBotBinding())
+  } catch (error) {
+    notify(error.message, true)
+  } finally {
+    event.currentTarget.disabled = false
+  }
+})
+
+document.querySelector('#qqbot-cancel').addEventListener('click', async (event) => {
+  event.currentTarget.disabled = true
+  try {
+    renderQqBot(await window.dshDesktop.cancelQqBotBinding())
+  } catch (error) {
+    notify(error.message, true)
+  } finally {
+    event.currentTarget.disabled = false
+  }
+})
+
+document.querySelector('#qqbot-unbind').addEventListener('click', async (event) => {
+  if (!window.confirm('解除 QQ 机器人绑定并清除本机加密凭据？')) return
+  event.currentTarget.disabled = true
+  try {
+    renderQqBot({ bound: false, binding: false }, 'restarting')
+    renderQqBot(await window.dshDesktop.unbindQqBot())
+    notify('QQ 机器人已解绑，DSH 已重启')
+  } catch (error) {
+    notify(error.message, true)
+    await refresh()
+  } finally {
+    event.currentTarget.disabled = false
+  }
+})
+
+window.dshDesktop.onQqBotEvent((payload) => {
+  renderQqBot(payload.status, payload.type)
+  if (payload.type === 'bound') notify('QQ 机器人绑定成功，DSH 已重启')
+  if (payload.type === 'error') notify(payload.error ?? 'QQ 机器人绑定失败', true)
+})
 
 for (const tab of document.querySelectorAll('[data-tab]')) {
   tab.addEventListener('click', () => {

--- a/apps/dsh-desktop/src/window-chrome.mjs
+++ b/apps/dsh-desktop/src/window-chrome.mjs
@@ -2,6 +2,27 @@ export const WINDOW_CHROME_HEIGHT = 46
 
 const WINDOW_CHROME_ID = 'dsh-desktop-window-chrome'
 
+export const WINDOW_CHROME_THEMES = Object.freeze({
+  dark: Object.freeze({ color: '#071117', symbolColor: '#d9edf4' }),
+  light: Object.freeze({ color: '#eef2f8', symbolColor: '#1f2937' }),
+})
+
+export function normalizeWindowChromeTheme(value) {
+  if (typeof value !== 'string' || !(value in WINDOW_CHROME_THEMES)) {
+    throw new TypeError(`invalid window chrome theme: ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+export function setWindowChromeTheme(browserWindow, rawTheme) {
+  const theme = normalizeWindowChromeTheme(rawTheme)
+  browserWindow?.setTitleBarOverlay?.({
+    ...WINDOW_CHROME_THEMES[theme],
+    height: WINDOW_CHROME_HEIGHT,
+  })
+  return theme
+}
+
 export const WINDOW_CHROME_CSS = `
 :root {
   --dsh-desktop-window-chrome-height: ${WINDOW_CHROME_HEIGHT}px;
@@ -27,17 +48,51 @@ html[data-dsh-desktop-window-chrome="true"] body {
   justify-content: space-between;
   padding: 0 154px 0 16px;
   overflow: hidden;
-  color: #d9edf4;
-  border-bottom: 1px solid rgba(114, 213, 238, 0.16);
-  background:
-    radial-gradient(circle at 17px 50%, rgba(105, 227, 255, 0.16), transparent 26px),
-    linear-gradient(90deg, rgba(79, 191, 219, 0.08), transparent 30%),
-    linear-gradient(180deg, #0b1a22 0%, #071117 100%);
-  box-shadow:
-    inset 0 1px rgba(225, 249, 255, 0.08),
-    0 10px 28px rgba(0, 4, 7, 0.24);
+  color: var(--dsh-desktop-chrome-fg, #d9edf4);
+  border-bottom: 1px solid var(--dsh-desktop-chrome-border, rgba(114, 213, 238, 0.16));
+  background: var(--dsh-desktop-chrome-bg, linear-gradient(180deg, #0b1a22, #071117));
+  box-shadow: var(--dsh-desktop-chrome-shadow, 0 10px 28px rgba(0, 4, 7, 0.24));
   font-family: "Bahnschrift", "Aptos Display", sans-serif;
   user-select: none;
+}
+
+html[data-dsh-desktop-chrome-theme="dark"] {
+  --dsh-desktop-chrome-fg: #d9edf4;
+  --dsh-desktop-chrome-border: rgba(114, 213, 238, 0.16);
+  --dsh-desktop-chrome-bg: radial-gradient(circle at 17px 50%, rgba(105, 227, 255, 0.16), transparent 26px), linear-gradient(90deg, rgba(79, 191, 219, 0.08), transparent 30%), linear-gradient(180deg, #0b1a22 0%, #071117 100%);
+  --dsh-desktop-chrome-shadow: inset 0 1px rgba(225, 249, 255, 0.08), 0 10px 28px rgba(0, 4, 7, 0.24);
+}
+
+html[data-dsh-desktop-chrome-theme="light"] {
+  --dsh-desktop-chrome-fg: #1f2937;
+  --dsh-desktop-chrome-border: rgba(71, 85, 105, 0.18);
+  --dsh-desktop-chrome-bg: radial-gradient(circle at 17px 50%, rgba(59, 130, 246, 0.12), transparent 26px), linear-gradient(90deg, rgba(59, 130, 246, 0.06), transparent 32%), linear-gradient(180deg, #f8fafc 0%, #eef2f8 100%);
+  --dsh-desktop-chrome-shadow: inset 0 1px rgba(255, 255, 255, 0.9), 0 8px 24px rgba(15, 23, 42, 0.1);
+}
+
+html[data-dsh-desktop-chrome-theme="light"] #${WINDOW_CHROME_ID} .dsh-window-chrome-title {
+  color: #111827;
+}
+
+html[data-dsh-desktop-chrome-theme="light"] #${WINDOW_CHROME_ID} .dsh-window-chrome-context,
+html[data-dsh-desktop-chrome-theme="light"] #${WINDOW_CHROME_ID} .dsh-window-chrome-mode {
+  color: rgba(51, 65, 85, 0.7);
+}
+
+html[data-dsh-desktop-chrome-theme="light"] #${WINDOW_CHROME_ID} .dsh-window-chrome-mark {
+  border-color: rgba(37, 99, 235, 0.42);
+  background: rgba(255, 255, 255, 0.76);
+}
+
+html[data-dsh-desktop-chrome-theme="light"] #${WINDOW_CHROME_ID} .dsh-window-chrome-mark::after {
+  background: #2563eb;
+  box-shadow: 0 0 7px rgba(37, 99, 235, 0.55);
+}
+
+html[data-dsh-desktop-window-chrome="true"] .dsh-desktop-modal-layer {
+  top: var(--dsh-desktop-window-chrome-height) !important;
+  height: calc(100vh - var(--dsh-desktop-window-chrome-height)) !important;
+  max-height: calc(100vh - var(--dsh-desktop-window-chrome-height)) !important;
 }
 
 #${WINDOW_CHROME_ID}::after {
@@ -145,12 +200,12 @@ html[data-dsh-desktop-window-chrome="true"] body {
 `
 
 export function windowChromeBrowserOptions() {
+  const theme = WINDOW_CHROME_THEMES.dark
   return {
     autoHideMenuBar: true,
     titleBarStyle: 'hidden',
     titleBarOverlay: {
-      color: '#071117',
-      symbolColor: '#d9edf4',
+      ...theme,
       height: WINDOW_CHROME_HEIGHT,
     },
   }
@@ -173,6 +228,45 @@ export function createWindowChromeScript({ title, context }) {
     chrome.querySelector('.dsh-window-chrome-context').textContent = data.context;
     document.documentElement.dataset.dshDesktopWindowChrome = 'true';
     document.body.prepend(chrome);
+
+    const isDark = () => {
+      if (document.body.hasAttribute('data-ds-dark-theme')) return true;
+      const scheme = getComputedStyle(document.documentElement).colorScheme;
+      if (scheme && scheme !== 'normal') return scheme.includes('dark');
+      const rgb = getComputedStyle(document.body).backgroundColor.match(/\\d+(?:\\.\\d+)?/g)?.slice(0, 3).map(Number);
+      return Array.isArray(rgb) && rgb.length === 3 && (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) < 128000;
+    };
+    let activeTheme;
+    const syncTheme = () => {
+      const theme = isDark() ? 'dark' : 'light';
+      if (document.documentElement.dataset.dshDesktopChromeTheme !== theme) {
+        document.documentElement.dataset.dshDesktopChromeTheme = theme;
+      }
+      if (theme !== activeTheme) {
+        activeTheme = theme;
+        window.dshDesktop?.setWindowChromeTheme?.(theme);
+      }
+    };
+    const markModalLayers = () => {
+      document.querySelectorAll('[role="dialog"], [aria-modal="true"], dialog[open]').forEach((dialog) => {
+        let layer = dialog;
+        while (layer.parentElement && layer.parentElement !== document.body) {
+          if (getComputedStyle(layer).position === 'fixed') break;
+          layer = layer.parentElement;
+        }
+        if (getComputedStyle(layer).position === 'fixed' && !layer.classList.contains('dsh-desktop-modal-layer')) {
+          layer.classList.add('dsh-desktop-modal-layer');
+        }
+      });
+    };
+    const sync = () => { syncTheme(); markModalLayers(); };
+    new MutationObserver(sync).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-ds-dark-theme'],
+      childList: true,
+      subtree: true,
+    });
+    sync();
     return true;
   })()`
 }

--- a/apps/dsh-desktop/test/extension-ipc.test.mjs
+++ b/apps/dsh-desktop/test/extension-ipc.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import test from 'node:test'
+
+import { registerExtensionIpc } from '../src/extension-ipc.mjs'
+
+class FakeIpcMain {
+  handlers = new Map()
+
+  removeHandler(channel) {
+    this.handlers.delete(channel)
+  }
+
+  handle(channel, handler) {
+    this.handlers.set(channel, handler)
+  }
+}
+
+test('extension IPC exposes only renderer-safe QQ Bot state and forwards lifecycle events', async () => {
+  const ipcMain = new FakeIpcMain()
+  const sent = []
+  const qqBotBinding = new EventEmitter()
+  qqBotBinding.status = () => ({ bound: true, binding: false, pending: false, appId: '12*****89' })
+  qqBotBinding.start = () => ({ bound: false, binding: true, pending: false })
+  qqBotBinding.cancel = () => ({ bound: false, binding: false, pending: false })
+  qqBotBinding.unbind = async () => ({ bound: false, binding: false, pending: false })
+  const unregister = registerExtensionIpc({
+    ipcMain,
+    dialog: {},
+    shell: {},
+    getWindow: () => ({ isDestroyed: () => false, webContents: { send: (...args) => sent.push(args) } }),
+    pluginManager: {},
+    controller: {},
+    ensureProfile: async () => {},
+    projectRoot: 'C:\\project',
+    dshHome: 'C:\\dsh',
+    qqBotBinding,
+  })
+
+  assert.deepEqual(await ipcMain.handlers.get('extensions:qqbot-status')(), {
+    bound: true,
+    binding: false,
+    pending: false,
+    appId: '12*****89',
+  })
+  assert.deepEqual(await ipcMain.handlers.get('extensions:qqbot-bind')(), { bound: false, binding: true, pending: false })
+  assert.deepEqual(await ipcMain.handlers.get('extensions:qqbot-cancel')(), { bound: false, binding: false, pending: false })
+  assert.deepEqual(await ipcMain.handlers.get('extensions:qqbot-unbind')(), { bound: false, binding: false, pending: false })
+
+  qqBotBinding.emit('event', { type: 'qr', status: { binding: true, qrImage: 'data:image/png;base64,abc' } })
+  assert.deepEqual(sent, [[
+    'extensions:qqbot-event',
+    { type: 'qr', status: { binding: true, qrImage: 'data:image/png;base64,abc' } },
+  ]])
+  assert.equal(JSON.stringify(sent).includes('appSecret'), false)
+
+  unregister()
+  assert.equal(ipcMain.handlers.has('extensions:qqbot-bind'), false)
+  assert.equal(qqBotBinding.listenerCount('event'), 0)
+})

--- a/apps/dsh-desktop/test/ipc.test.mjs
+++ b/apps/dsh-desktop/test/ipc.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { normalizeDesktopAction, publicRuntimeStatus } from '../src/ipc.mjs'
+import { normalizeDesktopAction, normalizeWindowChromeTheme, publicRuntimeStatus } from '../src/ipc.mjs'
 
 test('desktop action validation exposes only fixed recovery operations', () => {
   for (const action of ['retry', 'repair', 'open-logs', 'exit']) {
@@ -9,6 +9,14 @@ test('desktop action validation exposes only fixed recovery operations', () => {
   }
   for (const action of ['run-command', '../repair', '', 42]) {
     assert.throws(() => normalizeDesktopAction(action), /desktop action/)
+  }
+})
+
+test('window chrome IPC accepts only supported themes', () => {
+  assert.equal(normalizeWindowChromeTheme('light'), 'light')
+  assert.equal(normalizeWindowChromeTheme('dark'), 'dark')
+  for (const theme of ['', 'system', 42]) {
+    assert.throws(() => normalizeWindowChromeTheme(theme), /window chrome theme/)
   }
 })
 

--- a/apps/dsh-desktop/test/log-store.test.mjs
+++ b/apps/dsh-desktop/test/log-store.test.mjs
@@ -8,8 +8,8 @@ import { BoundedLogStore, sanitizeLogLine } from '../src/log-store.mjs'
 
 test('log sanitization removes common credential shapes', () => {
   assert.equal(
-    sanitizeLogLine('Authorization: Bearer secret-token NPM_TOKEN=abc123'),
-    'Authorization: Bearer [redacted] NPM_TOKEN=[redacted]',
+    sanitizeLogLine('Authorization: Bearer secret-token NPM_TOKEN=abc123 QQBOT_SECRET=qq-secret'),
+    'Authorization: Bearer [redacted] NPM_TOKEN=[redacted] QQBOT_SECRET=[redacted]',
   )
 })
 

--- a/apps/dsh-desktop/test/profile.test.mjs
+++ b/apps/dsh-desktop/test/profile.test.mjs
@@ -12,6 +12,7 @@ import {
   MANAGED_RUNTIME_PACKAGES,
   createDesktopProfileManifest,
   ensureDesktopProfile,
+  mergeDesktopPatch,
   materializeFilesystemPath,
   packagePathSegments,
   resolveRuntimePackages,
@@ -45,6 +46,24 @@ test('profile manifest preserves community bundles after managed bundles', () =>
   assert.equal(manifest.name, 'dsh-profile-desktop')
 })
 
+test('desktop profile includes both bundled plugin stores', () => {
+  assert.equal(BUILTIN_BUNDLES.includes('dshmarket'), true)
+  assert.equal(BUILTIN_BUNDLES.includes('dsh-plugin-hub'), true)
+  assert.equal(MANAGED_RUNTIME_PACKAGES.includes('dshmarket'), true)
+  assert.equal(MANAGED_RUNTIME_PACKAGES.includes('dsh-plugin-hub'), true)
+  assert.match(DESKTOP_PATCH_CONFIG, /id: dsh-market[\s\S]*profile: desktop/)
+})
+
+test('desktop patch refresh preserves skin and community-owned sections', () => {
+  const skinSection = '# --- dsh-skin managed (auto-generated; do not edit) ---\n- id: ui-skin-qq98\n# --- end dsh-skin managed ---'
+  const communityRow = "- id: community\n  name: '@community/plugin'"
+  const merged = mergeDesktopPatch(`${DESKTOP_PATCH_CONFIG}\n${skinSection}\n${communityRow}\n`)
+  assert.equal(merged.match(/dsh-desktop managed/gu)?.length, 2)
+  assert.match(merged, /ui-skin-qq98/u)
+  assert.match(merged, /@community\/plugin/u)
+  assert.equal(mergeDesktopPatch(merged), merged)
+})
+
 test('profile bootstrap is idempotent and links every managed package', async () => {
   const root = await mkdtemp(join(tmpdir(), 'dsh-desktop-profile-'))
   const dshHome = join(root, 'home')
@@ -59,13 +78,14 @@ test('profile bootstrap is idempotent and links every managed package', async ()
   }
 
   const first = await ensureDesktopProfile({ dshHome, packageRoots })
+  await writeFile(join(first.profileDir, 'cordis.patch.yml'), `${DESKTOP_PATCH_CONFIG}\n- id: retained\n`)
   const second = await ensureDesktopProfile({ dshHome, packageRoots })
   assert.equal(first.profileDir, second.profileDir)
   assert.equal(second.changed, false)
 
   const manifest = JSON.parse(await readFile(join(first.profileDir, 'package.json'), 'utf8'))
   assert.deepEqual(manifest.dsh.profile.bundles, BUILTIN_BUNDLES)
-  assert.equal(await readFile(join(first.profileDir, 'cordis.patch.yml'), 'utf8'), DESKTOP_PATCH_CONFIG)
+  assert.equal(await readFile(join(first.profileDir, 'cordis.patch.yml'), 'utf8'), `${DESKTOP_PATCH_CONFIG.trimEnd()}\n\n- id: retained\n`)
   for (const [packageName, source] of packageRoots) {
     const linked = join(first.profileDir, 'node_modules', ...packagePathSegments(packageName))
     assert.equal(await realpath(linked), await realpath(source))
@@ -107,6 +127,9 @@ test('official DSH CLI composes the isolated desktop profile', async () => {
     assert.match(result.stdout, /dsh-host-directory-picker-browse/)
     assert.match(result.stdout, /directory-picker-desktop-client/)
     assert.match(result.stdout, /dsh-client-ui-directory-picker-browse/)
+    assert.match(result.stdout, /- id: dsh-market/)
+    assert.match(result.stdout, /profile: desktop/)
+    assert.match(result.stdout, /- id: dsh-plugin-hub/)
     assert.doesNotMatch(result.stdout, /dsh-host-directory-picker-native/)
   } finally {
     await rm(root, { recursive: true, force: true })

--- a/apps/dsh-desktop/test/profile.test.mjs
+++ b/apps/dsh-desktop/test/profile.test.mjs
@@ -54,6 +54,11 @@ test('desktop profile includes both bundled plugin stores', () => {
   assert.match(DESKTOP_PATCH_CONFIG, /id: dsh-market[\s\S]*profile: desktop/)
 })
 
+test('desktop profile includes the official QQ Bot bundle', () => {
+  assert.equal(BUILTIN_BUNDLES.includes('@tencent-connect/dsh-qqbot'), true)
+  assert.equal(MANAGED_RUNTIME_PACKAGES.includes('@tencent-connect/dsh-qqbot'), true)
+})
+
 test('desktop patch refresh preserves skin and community-owned sections', () => {
   const skinSection = '# --- dsh-skin managed (auto-generated; do not edit) ---\n- id: ui-skin-qq98\n# --- end dsh-skin managed ---'
   const communityRow = "- id: community\n  name: '@community/plugin'"
@@ -78,14 +83,19 @@ test('profile bootstrap is idempotent and links every managed package', async ()
   }
 
   const first = await ensureDesktopProfile({ dshHome, packageRoots })
-  await writeFile(join(first.profileDir, 'cordis.patch.yml'), `${DESKTOP_PATCH_CONFIG}\n- id: retained\n`)
+  const firstPatch = await readFile(join(first.profileDir, 'cordis.patch.yml'), 'utf8')
+  await writeFile(join(first.profileDir, 'cordis.patch.yml'), `${firstPatch}\n- id: retained\n`)
   const second = await ensureDesktopProfile({ dshHome, packageRoots })
+  const third = await ensureDesktopProfile({ dshHome, packageRoots })
   assert.equal(first.profileDir, second.profileDir)
-  assert.equal(second.changed, false)
+  assert.equal(second.changed, true)
+  assert.equal(third.changed, false)
 
   const manifest = JSON.parse(await readFile(join(first.profileDir, 'package.json'), 'utf8'))
   assert.deepEqual(manifest.dsh.profile.bundles, BUILTIN_BUNDLES)
-  assert.equal(await readFile(join(first.profileDir, 'cordis.patch.yml'), 'utf8'), `${DESKTOP_PATCH_CONFIG.trimEnd()}\n\n- id: retained\n`)
+  const retainedPatch = await readFile(join(first.profileDir, 'cordis.patch.yml'), 'utf8')
+  assert.match(retainedPatch, /id: im-qqbot\n  disabled: true/u)
+  assert.match(retainedPatch, /- id: retained/u)
   for (const [packageName, source] of packageRoots) {
     const linked = join(first.profileDir, 'node_modules', ...packagePathSegments(packageName))
     assert.equal(await realpath(linked), await realpath(source))
@@ -130,6 +140,7 @@ test('official DSH CLI composes the isolated desktop profile', async () => {
     assert.match(result.stdout, /- id: dsh-market/)
     assert.match(result.stdout, /profile: desktop/)
     assert.match(result.stdout, /- id: dsh-plugin-hub/)
+    assert.match(result.stdout, /- id: im-qqbot[\s\S]*?disabled: true/)
     assert.doesNotMatch(result.stdout, /dsh-host-directory-picker-native/)
   } finally {
     await rm(root, { recursive: true, force: true })

--- a/apps/dsh-desktop/test/qqbot.test.mjs
+++ b/apps/dsh-desktop/test/qqbot.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  QQBOT_PATCH_START,
+  QqBotBindingService,
+  QqBotCredentialStore,
+  maskAppId,
+  mergeQqBotPatch,
+  readQqBotPatchEnabled,
+  setQqBotProfileEnabled,
+} from '../src/extensions/qqbot.mjs'
+
+const tick = () => new Promise((resolve) => setImmediate(resolve))
+
+test('QQ Bot patch state is isolated and preserves every other managed section', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-desktop-qqbot-patch-'))
+  const profileDir = join(root, 'profiles', 'desktop')
+  const patchPath = join(profileDir, 'cordis.patch.yml')
+  const original = '# --- dsh-desktop managed (auto-generated; do not edit) ---\n- id: desktop\n# --- end dsh-desktop managed ---\n\n- id: community\n'
+  try {
+    await mkdir(profileDir, { recursive: true })
+    await writeFile(patchPath, original)
+    await setQqBotProfileEnabled({ profileDir, enabled: false })
+    let content = await readFile(patchPath, 'utf8')
+    assert.match(content, /id: im-qqbot\n  disabled: true/u)
+    assert.equal(readQqBotPatchEnabled(content), false)
+    assert.match(content, /id: community/u)
+    await setQqBotProfileEnabled({ profileDir, enabled: true })
+    content = await readFile(patchPath, 'utf8')
+    assert.match(content, /id: im-qqbot\n  disabled: false/u)
+    assert.equal(readQqBotPatchEnabled(content), true)
+    assert.equal(content.split(QQBOT_PATCH_START).length - 1, 1)
+    assert.equal(mergeQqBotPatch(content, true), content)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('credential store encrypts the complete payload and never persists plaintext', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-desktop-qqbot-store-'))
+  const path = join(root, 'qqbot.json')
+  const safeStorage = {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(`protected:${Buffer.from(value).toString('base64')}`),
+    decryptString: (value) => Buffer.from(value.toString().slice('protected:'.length), 'base64').toString(),
+  }
+  const store = new QqBotCredentialStore({ path, safeStorage })
+  try {
+    await store.save({ appId: '123456789', appSecret: 'top-secret-value' })
+    const disk = await readFile(path, 'utf8')
+    assert.doesNotMatch(disk, /123456789|top-secret-value/u)
+    assert.deepEqual(await store.load(), { appId: '123456789', appSecret: 'top-secret-value' })
+    await store.clear()
+    assert.equal(await store.load(), undefined)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('binding service publishes a QR image, saves credentials, enables the profile, and restarts', async () => {
+  let callbacks
+  const calls = []
+  const events = []
+  const service = new QqBotBindingService({
+    credentialStore: { save: async (value) => calls.push(['save', value]), clear: async () => {} },
+    startQrConnect: (value, options) => {
+      callbacks = value
+      assert.equal(options.displayQrCodeToConsole, false)
+      return () => calls.push(['stop'])
+    },
+    renderQr: async (url) => `data:image/png;base64,${Buffer.from(url).toString('base64')}`,
+    setProfileEnabled: async (enabled) => calls.push(['profile', enabled]),
+    setRuntimeCredentials: (value) => calls.push(['runtime', value]),
+    restartRuntime: async () => calls.push(['restart']),
+  })
+  service.on('event', (event) => events.push(event))
+
+  assert.equal(service.start().binding, true)
+  callbacks.onQrDisplayed('https://example.test/qr')
+  await tick()
+  assert.match(service.status().qrImage, /^data:image\/png;base64,/u)
+  callbacks.onSuccess([{ appId: '123456789', appSecret: 'never-rendered' }])
+  await tick()
+  await tick()
+
+  assert.deepEqual(service.status(), { bound: true, binding: false, pending: false, appId: '12*****89', qrImage: undefined })
+  assert.deepEqual(calls.map(([name]) => name), ['save', 'profile', 'runtime', 'restart'])
+  assert.equal(events.some((event) => JSON.stringify(event).includes('never-rendered')), false)
+  assert.equal(events.at(-1).type, 'bound')
+})
+
+test('binding cancellation ignores the connector failure callback and unbind clears state', async () => {
+  let callbacks
+  let stopped = false
+  const calls = []
+  const service = new QqBotBindingService({
+    initialCredentials: undefined,
+    credentialStore: { save: async () => {}, clear: async () => calls.push('clear') },
+    startQrConnect: (value) => {
+      callbacks = value
+      return () => {
+        stopped = true
+        callbacks.onFailure(new Error('canceled by connector'))
+      }
+    },
+    renderQr: async () => 'data:image/png;base64,qr',
+    setProfileEnabled: async (enabled) => calls.push(`profile:${enabled}`),
+    setRuntimeCredentials: (value) => calls.push(`runtime:${String(value)}`),
+    restartRuntime: async () => calls.push('restart'),
+  })
+  service.start()
+  assert.equal(service.cancel().binding, false)
+  assert.equal(stopped, true)
+
+  const boundService = new QqBotBindingService({
+    initialCredentials: { appId: 'abcd1234', appSecret: 'secret' },
+    credentialStore: service.credentialStore,
+    startQrConnect: service.startQrConnect,
+    setProfileEnabled: service.setProfileEnabled,
+    setRuntimeCredentials: service.setRuntimeCredentials,
+    restartRuntime: service.restartRuntime,
+  })
+  assert.equal((await boundService.unbind()).bound, false)
+  assert.deepEqual(calls, ['clear', 'profile:false', 'runtime:undefined', 'restart'])
+  assert.equal(maskAppId('abcd1234'), 'ab****34')
+})
+
+test('unbind is serialized after an in-flight credential save', async () => {
+  let callbacks
+  let releaseSave
+  let connectorStarts = 0
+  const calls = []
+  const service = new QqBotBindingService({
+    credentialStore: {
+      save: async () => {
+        calls.push('save')
+        await new Promise((resolve) => { releaseSave = resolve })
+      },
+      clear: async () => calls.push('clear'),
+    },
+    startQrConnect: (value) => {
+      connectorStarts += 1
+      callbacks = value
+      return () => {}
+    },
+    setProfileEnabled: async (enabled) => calls.push(`profile:${enabled}`),
+    setRuntimeCredentials: (value) => calls.push(`runtime:${value ? 'set' : 'clear'}`),
+    restartRuntime: async () => calls.push('restart'),
+  })
+
+  service.start()
+  callbacks.onSuccess([{ appId: '123456789', appSecret: 'secret' }])
+  assert.equal(service.status().pending, true)
+  service.start()
+  assert.equal(connectorStarts, 1)
+  const unbinding = service.unbind()
+  await tick()
+  assert.deepEqual(calls, ['save'])
+  releaseSave()
+  assert.equal((await unbinding).bound, false)
+  assert.deepEqual(calls, [
+    'save',
+    'profile:true',
+    'runtime:set',
+    'restart',
+    'clear',
+    'profile:false',
+    'runtime:clear',
+    'restart',
+  ])
+})

--- a/apps/dsh-desktop/test/runtime-controller.test.mjs
+++ b/apps/dsh-desktop/test/runtime-controller.test.mjs
@@ -75,6 +75,7 @@ test('controller reaches ready state from streamed output and stops cleanly', as
     probeReady: async () => {},
     startupTimeoutMs: 2_000,
     pathEntries: ['C:\\desktop-runtime-bin'],
+    environmentProvider: () => ({ QQBOT_APPID: 'desktop-app', QQBOT_SECRET: 'runtime-only' }),
   })
   controller.on('status', (status) => states.push(status.state))
 
@@ -86,6 +87,8 @@ test('controller reaches ready state from streamed output and stops cleanly', as
   assert.ok(logLines.some((line) => line.includes('booting')))
   assert.equal(childEnvironment.DSH_PROFILE, 'desktop')
   assert.equal(childEnvironment.DSH_SKIN_PROFILE, 'desktop')
+  assert.equal(childEnvironment.QQBOT_APPID, 'desktop-app')
+  assert.equal(childEnvironment.QQBOT_SECRET, 'runtime-only')
   assert.ok(childEnvironment.PATH.startsWith(`C:\\desktop-runtime-bin${process.platform === 'win32' ? ';' : ':'}`))
 
   await controller.stop()

--- a/apps/dsh-desktop/test/runtime-controller.test.mjs
+++ b/apps/dsh-desktop/test/runtime-controller.test.mjs
@@ -62,14 +62,19 @@ test('controller reaches ready state from streamed output and stops cleanly', as
   const child = new FakeChild()
   const logLines = []
   const states = []
+  let childEnvironment
   const controller = new DshRuntimeController({
     cliPath: 'dsh-bin.js',
     cwd: process.cwd(),
     dshHome: 'C:\\isolated-home',
-    spawnProcess: () => child,
+    spawnProcess: (_executable, _arguments, options) => {
+      childEnvironment = options.env
+      return child
+    },
     logStore: { append: async (line) => logLines.push(line) },
     probeReady: async () => {},
     startupTimeoutMs: 2_000,
+    pathEntries: ['C:\\desktop-runtime-bin'],
   })
   controller.on('status', (status) => states.push(status.state))
 
@@ -79,6 +84,9 @@ test('controller reaches ready state from streamed output and stops cleanly', as
   assert.equal(controller.status.state, 'ready')
   assert.deepEqual(states.slice(0, 2), ['starting', 'ready'])
   assert.ok(logLines.some((line) => line.includes('booting')))
+  assert.equal(childEnvironment.DSH_PROFILE, 'desktop')
+  assert.equal(childEnvironment.DSH_SKIN_PROFILE, 'desktop')
+  assert.ok(childEnvironment.PATH.startsWith(`C:\\desktop-runtime-bin${process.platform === 'win32' ? ';' : ':'}`))
 
   await controller.stop()
   assert.equal(controller.status.state, 'stopped')

--- a/apps/dsh-desktop/test/runtime-integration.test.mjs
+++ b/apps/dsh-desktop/test/runtime-integration.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -62,12 +62,29 @@ test('official DSH host serves the complete desktop profile', { timeout: 60_000 
       })
       assert.equal(bundle.ok, true, `${skinId} skin bundle was not served`)
     }
+    const marketStatus = await fetch(new URL('/dsh-market/installed', url), {
+      signal: AbortSignal.timeout(5_000),
+    })
+    assert.equal(marketStatus.ok, true, 'dshmarket status route was not served')
+    assert.equal((await marketStatus.json()).profile, 'desktop')
 
     browser = await chromium.launch({ headless: true })
     const page = await browser.newPage()
     await page.goto(url, { waitUntil: 'domcontentloaded' })
     await page.locator('[data-pet-dock]').waitFor({ state: 'attached', timeout: 10_000 })
     await page.getByRole('button', { name: 'whale girl' }).waitFor({ state: 'visible', timeout: 10_000 })
+    await page.getByRole('button', { name: '插件商店' }).waitFor({ state: 'visible', timeout: 10_000 })
+
+    const applySkin = await fetch(new URL('/api/skin-center/apply', url), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ skin: 'qq98' }),
+      signal: AbortSignal.timeout(5_000),
+    })
+    assert.equal(applySkin.ok, true)
+    assert.equal((await applySkin.json()).active, 'qq98')
+    const desktopPatch = await readFile(join(root, 'profiles', 'desktop', 'cordis.patch.yml'), 'utf8')
+    assert.match(desktopPatch, /- id: ui-skin-qq98/u)
   } catch (error) {
     error.message = `${error.message}\nRecent runtime log:\n${await logs.tail(80)}`
     throw error

--- a/apps/dsh-desktop/test/runtime-tools.test.mjs
+++ b/apps/dsh-desktop/test/runtime-tools.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { ensurePnpmCommandShim } from '../src/electron-app.mjs'
+
+test('bundled pnpm is exposed to in-process plugin stores without a system install', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-runtime-tools-'))
+  try {
+    const directory = await ensurePnpmCommandShim({
+      directory: join(root, 'bin'),
+      executable: 'C:\\Program Files\\DeepSeek Harness Desktop\\app.exe',
+      pnpmCli: 'C:\\Program Files\\DeepSeek Harness Desktop\\resources\\pnpm.mjs',
+    })
+    const name = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+    const command = await readFile(join(directory, name), 'utf8')
+    assert.match(command, /ELECTRON_RUN_AS_NODE=1/u)
+    assert.match(command, /pnpm\.mjs/u)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/apps/dsh-desktop/test/window-chrome.test.mjs
+++ b/apps/dsh-desktop/test/window-chrome.test.mjs
@@ -7,10 +7,12 @@ import {
   installWindowChrome,
   WINDOW_CHROME_CSS,
   WINDOW_CHROME_HEIGHT,
+  normalizeWindowChromeTheme,
+  setWindowChromeTheme,
   windowChromeBrowserOptions,
 } from '../src/window-chrome.mjs'
 
-test('window chrome uses a native overlay with a compact dark caption area', () => {
+test('window chrome uses a native overlay with a compact caption area', () => {
   assert.equal(WINDOW_CHROME_HEIGHT, 46)
   assert.deepEqual(windowChromeBrowserOptions(), {
     autoHideMenuBar: true,
@@ -23,6 +25,8 @@ test('window chrome uses a native overlay with a compact dark caption area', () 
   })
   assert.match(WINDOW_CHROME_CSS, /-webkit-app-region: drag/)
   assert.match(WINDOW_CHROME_CSS, /padding-top: var\(--dsh-desktop-window-chrome-height\)/)
+  assert.match(WINDOW_CHROME_CSS, /data-dsh-desktop-chrome-theme="light"/)
+  assert.match(WINDOW_CHROME_CSS, /dsh-desktop-modal-layer/)
 })
 
 test('window chrome script keeps labels as text content', () => {
@@ -32,7 +36,20 @@ test('window chrome script keeps labels as text content', () => {
   })
   assert.match(script, /textContent = data\.title/)
   assert.match(script, /textContent = data\.context/)
+  assert.match(script, /MutationObserver/)
+  assert.match(script, /setWindowChromeTheme/)
+  assert.match(script, /dsh-desktop-modal-layer/)
   assert.doesNotMatch(script, /DeepSeek <Harness><\/span>/)
+})
+
+test('window chrome theme validation and native overlay are bounded', () => {
+  assert.equal(normalizeWindowChromeTheme('light'), 'light')
+  assert.equal(normalizeWindowChromeTheme('dark'), 'dark')
+  assert.throws(() => normalizeWindowChromeTheme('transparent'), /window chrome theme/)
+  const calls = []
+  const browserWindow = { setTitleBarOverlay: (options) => calls.push(options) }
+  assert.equal(setWindowChromeTheme(browserWindow, 'light'), 'light')
+  assert.deepEqual(calls, [{ color: '#eef2f8', symbolColor: '#1f2937', height: 46 }])
 })
 
 test('window chrome applies CSS before mounting the drag surface', async () => {

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -4,7 +4,7 @@
 
 The desktop application is a thin lifecycle and security layer around the official DSH host. Electron starts `@deepseek-ai/dsh` with `--profile desktop --port 0`, waits for the official loopback URL line, probes HTTP readiness, and then loads that URL into the main window. The Web application, protocols, data paths, tools, and plugin system remain DSH implementations.
 
-The managed profile lives at `~/.dsh/profiles/desktop`. It composes `@deepseek-ai/dsh-base`, `@deepseek-ai/dsh-web-app`, and `@deepseek-ai/dsh-web-ui-all`, while preserving community bundles already added to the desktop profile. Existing default profiles are not changed.
+The DSH home remains `DSH_HOME` or `~/.dsh`. The desktop app runs the managed `~/.dsh/profiles/desktop` profile, which composes `@deepseek-ai/dsh-base`, `@deepseek-ai/dsh-web-app`, `@linxin666/dsh-web-ui-all`, `dshmarket`, and `dsh-plugin-hub` while preserving community bundles already added to that profile. Packaged plugin directories are linked into the profile's `node_modules`; this is runtime package resolution, not a second configuration store. Existing default profiles are not changed.
 
 ## Included desktop capabilities
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -4,7 +4,7 @@
 
 The desktop application is a thin lifecycle and security layer around the official DSH host. Electron starts `@deepseek-ai/dsh` with `--profile desktop --port 0`, waits for the official loopback URL line, probes HTTP readiness, and then loads that URL into the main window. The Web application, protocols, data paths, tools, and plugin system remain DSH implementations.
 
-The DSH home remains `DSH_HOME` or `~/.dsh`. The desktop app runs the managed `~/.dsh/profiles/desktop` profile, which composes `@deepseek-ai/dsh-base`, `@deepseek-ai/dsh-web-app`, `@linxin666/dsh-web-ui-all`, `dshmarket`, and `dsh-plugin-hub` while preserving community bundles already added to that profile. Packaged plugin directories are linked into the profile's `node_modules`; this is runtime package resolution, not a second configuration store. Existing default profiles are not changed.
+The DSH home remains `DSH_HOME` or `~/.dsh`. The desktop app runs the managed `~/.dsh/profiles/desktop` profile, which composes `@deepseek-ai/dsh-base`, `@deepseek-ai/dsh-web-app`, `@linxin666/dsh-web-ui-all`, `@tencent-connect/dsh-qqbot`, `dshmarket`, and `dsh-plugin-hub` while preserving community bundles already added to that profile. Packaged plugin directories are linked into the profile's `node_modules`; this is runtime package resolution, not a second configuration store. Existing default profiles are not changed.
 
 ## Included desktop capabilities
 
@@ -46,6 +46,8 @@ Starting with version 0.1.3, the installed app checks stable GitHub Releases aft
 Open `Tools > Extension Dock` from the native menu.
 
 Plugin installation accepts an npm registry package such as `@scope/dsh-bundle@1.2.3`. URL, path, whitespace, shell metacharacter, and option-like input is rejected. The package must declare a DSH bundle patch. Built-in packages cannot be removed.
+
+The built-in Tencent QQ Bot integration is disabled until it is bound from Extension Dock. Binding uses the official QR connector inside the desktop main process. The AppSecret is encrypted with the operating-system credential store, is never sent to renderer code, and is supplied to the DSH child process only through its environment. Unbinding deletes the encrypted credential, disables the profile row, and restarts DSH.
 
 Skill discovery scans project `.dsh/skills`, project `.agents/skills`, user DSH skills, and user Agents skills in precedence order. Import copies one validated skill folder into `~/.dsh/skills` without overwriting an existing name.
 

--- a/docs/launch/release-notes.md
+++ b/docs/launch/release-notes.md
@@ -1,45 +1,47 @@
-# DeepSeek Harness Desktop 0.1.4
+# DeepSeek Harness Desktop 0.1.5
 
 ## 中文
 
 ### 本次亮点
 
-- 鲸鱼娘桌宠现在挂载到 DSH 的全局 Shell Overlay，不再依赖新版界面已经停止渲染的会话输入插槽。首次启动、空白会话页、已有会话和设置窗口中都能正常看到桌宠，拖动、抚摸、喂食、隐藏与重新召唤仍沿用原有持久化状态。
-- 修复 DSH rc.6 Host API 会过滤第三方设置命名空间的问题。设置 → 插件 → Web UI 插件现在完整显示移动端远程控制、皮肤中心、实时令牌估算、任务看板和宠物五张配置卡，不会再只剩一张皮肤中心卡片。
-- 皮肤中心已重新生成并构建，完整列出桌面版随附的 9 套可选皮肤，包括初音未来与交易终端。安装时选择全家桶后，每套皮肤的清单、客户端脚本和即时试穿入口都会一并进入桌面发行包。
+- 顶部标题栏会随 DSH 亮色与暗色主题即时切换，原生 Windows 最小化、最大化和关闭按钮也使用匹配的颜色，不再在亮色界面上保留黑条。
+- 设置等全屏弹窗现在使用标题栏下方的安全可视区域，上边框和圆角不会再被 46 像素标题栏截断。
+- 修复安装版皮肤中心仍扫描源码目录、并写入错误配置层的问题。它现在从 `~/.dsh/profiles/desktop/node_modules` 读取随安装包提供的 9 套皮肤，并更新 `~/.dsh/profiles/desktop/cordis.patch.yml`，即时试穿与正式应用都可用。
+- 内置 `dshmarket` 1.0.3 和 `dsh-plugin-hub` 0.1.0。两个插件随桌面 profile 启动，`dshmarket` 的安装与更新目标已明确设为 `desktop` profile。
 
 ### 验证
 
-- 新增真实 DSH Host 集成检查：验证五个自定义设置命名空间均可从配置接口读取，桌宠状态、角色清单和精灵图资源均可访问，并用无头浏览器确认鲸鱼娘按钮真实出现在页面上。
-- 新增全部 9 套皮肤脚本的运行时检查，并在打包校验中逐一确认每个皮肤包的 `skin.json` 与 `lib/client.js` 存在。
-- 桌宠包额外校验 `lib/client.js`、`assets/whale/pet.json` 与 `assets/whale/spritesheet.webp`，防止以后再次出现“代码已安装但角色资源未进入安装包”的回归。
+- Electron 端到端检查实际切换标题栏明暗样式，并确认 DSH 标准弹窗容器从标题栏下方开始。
+- 真实 DSH Host 集成检查会加载两个插件商店、访问市场状态接口、确认插件商店入口可见，并实际应用 QQ98 皮肤后检查桌面 profile patch。
+- 打包校验继续逐一检查全部内置运行时包、9 套皮肤清单与客户端 bundle。
 
 ### 下载与校验
 
-下载 `DeepSeek-Harness-Desktop-Setup-0.1.4-x64.exe`，并使用同一 GitHub Release 中的 `SHA256SUMS.txt` 校验安装包。应用内更新会先显示版本号、发布时间与本页更新内容，只有用户确认后才会下载；安装和重启也会再次请求确认。
+下载 `DeepSeek-Harness-Desktop-Setup-0.1.5-x64.exe`，并使用同一 GitHub Release 中的 `SHA256SUMS.txt` 校验安装包。应用内更新只会在用户确认后下载，安装与重启也会再次请求确认。
 
 ### 说明
 
-这是社区构建版本，并非 DeepSeek 官方发行版。当前安装包未使用商业代码签名证书，Windows SmartScreen 可能显示“未知发布者”。请只从本项目的 GitHub Release 页面下载，并优先使用经过自动化验证的默认安装路径。若从旧版本升级，现有桌宠名字、亲密度、位置和皮肤配置都会保留。
+这是社区构建版本，并非 DeepSeek 官方发行版。当前安装包未使用商业代码签名证书，Windows SmartScreen 可能显示“未知发布者”。请只从本项目的 GitHub Release 页面下载并核对 SHA-256。升级会保留现有 DSH_HOME、桌面 profile、桌宠状态和皮肤配置。
 
 ## English
 
 ### Highlights
 
-- The whale-girl desktop pet now mounts in the root-scoped DSH Shell Overlay instead of a conversation input slot that the rc.6 interface no longer renders. The companion is visible on first launch, on the empty conversation screen, inside active sessions, and while the settings window is open. Existing dragging, petting, feeding, hiding, summoning, naming, and persisted affinity behavior remains unchanged.
-- The rc.6 Host API filters settings namespaces through an explicit security allowlist. This release adds only the five bundled Web UI namespaces to that boundary. Settings → Plugins → Web UI Plugins now shows Remote Control, Skin Center, Live Token Estimates, Task Board, and Pet instead of silently hiding four cards.
-- The Skin Center registry and client bundle were regenerated. All nine selectable skins shipped by the desktop aggregate are listed, including Miku and Trading Terminal, and their real client bundles remain available for instant try-on and one-click application.
+- The title bar now follows the live DSH light/dark theme. Native Windows minimize, maximize, and close buttons receive matching colors, removing the black strip from light themes.
+- Full-screen dialogs such as Settings now use the safe viewport below the 46-pixel title bar, so their top border and rounded corners are no longer clipped.
+- Fixed packaged Skin Center discovery and configuration. It now reads all nine bundled skins from `~/.dsh/profiles/desktop/node_modules` and updates `~/.dsh/profiles/desktop/cordis.patch.yml`, restoring both live try-on and permanent application.
+- Bundled `dshmarket` 1.0.3 and `dsh-plugin-hub` 0.1.0. Both start with the desktop profile, and `dshmarket` explicitly installs and updates packages in that profile.
 
 ### Verification
 
-- The real DSH Host integration test now reads the settings API and asserts that all five custom namespaces are exposed. It also verifies the pet state endpoint, character manifest, sprite sheet, and every installed skin bundle.
-- A headless Chromium check waits for the actual whale-girl control in the rendered page, covering the slot regression that endpoint-only tests previously missed.
-- Packaged-payload verification now checks each skin's `skin.json` and `lib/client.js`, plus the pet client, manifest, and sprite atlas. This prevents a release from passing when profile metadata exists but visual assets were omitted.
+- Electron end-to-end coverage switches the real title bar between light and dark styling and verifies that standard DSH dialogs begin below the title bar.
+- The real DSH Host integration test loads both plugin stores, checks the marketplace endpoint and store UI entry, applies QQ98, and verifies the desktop profile patch.
+- Packaged-payload verification continues to inspect every managed runtime package and all nine skin manifests and client bundles.
 
 ### Download and verification
 
-Download `DeepSeek-Harness-Desktop-Setup-0.1.4-x64.exe` and verify it with `SHA256SUMS.txt` from the same GitHub Release. The built-in updater displays the target version, publication time, and these notes before downloading. Downloading begins only after user confirmation, and installation plus restart requires a second confirmation.
+Download `DeepSeek-Harness-Desktop-Setup-0.1.5-x64.exe` and verify it with `SHA256SUMS.txt` from the same GitHub Release. The built-in updater downloads only after user confirmation and asks again before installation and restart.
 
 ### Notice
 
-This is a community build and not an official DeepSeek distribution. It is not signed with a commercial code-signing certificate, so Windows SmartScreen may report an unknown publisher. Download only from this project's GitHub Release page and prefer the automatically verified default installation path. Upgrading preserves the existing pet name, affinity, position, visibility, and selected skin configuration.
+This is a community build and not an official DeepSeek distribution. It is not signed with a commercial code-signing certificate, so Windows SmartScreen may report an unknown publisher. Download only from this project's GitHub Release page and verify the SHA-256 checksum. Upgrading preserves the existing DSH home, desktop profile, pet state, and skin configuration.

--- a/docs/launch/release-notes.md
+++ b/docs/launch/release-notes.md
@@ -1,47 +1,47 @@
-# DeepSeek Harness Desktop 0.1.5
+# DeepSeek Harness Desktop 0.1.6
 
 ## 中文
 
 ### 本次亮点
 
-- 顶部标题栏会随 DSH 亮色与暗色主题即时切换，原生 Windows 最小化、最大化和关闭按钮也使用匹配的颜色，不再在亮色界面上保留黑条。
-- 设置等全屏弹窗现在使用标题栏下方的安全可视区域，上边框和圆角不会再被 46 像素标题栏截断。
-- 修复安装版皮肤中心仍扫描源码目录、并写入错误配置层的问题。它现在从 `~/.dsh/profiles/desktop/node_modules` 读取随安装包提供的 9 套皮肤，并更新 `~/.dsh/profiles/desktop/cordis.patch.yml`，即时试穿与正式应用都可用。
-- 内置 `dshmarket` 1.0.3 和 `dsh-plugin-hub` 0.1.0。两个插件随桌面 profile 启动，`dshmarket` 的安装与更新目标已明确设为 `desktop` profile。
+- 内置腾讯官方 `@tencent-connect/dsh-qqbot` 0.2.0，并固定安装到隔离的 `desktop` profile。QQ 私聊与群聊现在可以直接接入桌面版 Harness。
+- 扩展坞新增 QQ 机器人绑定卡片。首次使用会在桌面窗口显示可自动刷新的二维码，支持取消、重新绑定和解除绑定，不再依赖不可见的后台终端。
+- 未绑定时 QQ Bot 插件保持禁用，不会在启动阶段等待终端扫码或影响 Web UI 就绪；扫码成功后会自动启用插件并重启 DSH。
+- AppSecret 使用 Electron `safeStorage` 和 Windows 系统凭据保护加密保存，只注入 DSH 子进程环境，不会发送给渲染页面、写入运行日志或明文落到 `cordis.patch.yml`。
 
 ### 验证
 
-- Electron 端到端检查实际切换标题栏明暗样式，并确认 DSH 标准弹窗容器从标题栏下方开始。
-- 真实 DSH Host 集成检查会加载两个插件商店、访问市场状态接口、确认插件商店入口可见，并实际应用 QQ98 皮肤后检查桌面 profile patch。
-- 打包校验继续逐一检查全部内置运行时包、9 套皮肤清单与客户端 bundle。
+- 53 项桌面测试覆盖 profile 合成、加密凭据边界、二维码生命周期、取消与解绑、IPC 安全载荷、运行时环境注入和真实 DSH Host 启动。
+- Electron 端到端检查已调用腾讯官方 Connector 获取真实二维码，并确认二维码可在扩展坞正确显示和取消，过程中未完成绑定或保存凭据。
+- 打包校验会确认官方 QQ Bot 包及其运行依赖存在于安装版，并继续检查所有桌面运行时包、皮肤清单和客户端 bundle。
 
 ### 下载与校验
 
-下载 `DeepSeek-Harness-Desktop-Setup-0.1.5-x64.exe`，并使用同一 GitHub Release 中的 `SHA256SUMS.txt` 校验安装包。应用内更新只会在用户确认后下载，安装与重启也会再次请求确认。
+下载 `DeepSeek-Harness-Desktop-Setup-0.1.6-x64.exe`，并使用同一 GitHub Release 中的 `SHA256SUMS.txt` 校验安装包。应用内更新只会在用户确认后下载，安装与重启也会再次请求确认。
 
 ### 说明
 
-这是社区构建版本，并非 DeepSeek 官方发行版。当前安装包未使用商业代码签名证书，Windows SmartScreen 可能显示“未知发布者”。请只从本项目的 GitHub Release 页面下载并核对 SHA-256。升级会保留现有 DSH_HOME、桌面 profile、桌宠状态和皮肤配置。
+这是社区构建版本，并非 DeepSeek 或腾讯官方发行版。QQ Bot 插件和扫码 Connector 来自腾讯官方 npm 包。当前安装包未使用商业代码签名证书，Windows SmartScreen 可能显示“未知发布者”。请只从本项目的 GitHub Release 页面下载并核对 SHA-256。升级会保留现有 DSH_HOME、桌面 profile、桌宠状态、皮肤配置和已加密的 QQ Bot 绑定凭据。
 
 ## English
 
 ### Highlights
 
-- The title bar now follows the live DSH light/dark theme. Native Windows minimize, maximize, and close buttons receive matching colors, removing the black strip from light themes.
-- Full-screen dialogs such as Settings now use the safe viewport below the 46-pixel title bar, so their top border and rounded corners are no longer clipped.
-- Fixed packaged Skin Center discovery and configuration. It now reads all nine bundled skins from `~/.dsh/profiles/desktop/node_modules` and updates `~/.dsh/profiles/desktop/cordis.patch.yml`, restoring both live try-on and permanent application.
-- Bundled `dshmarket` 1.0.3 and `dsh-plugin-hub` 0.1.0. Both start with the desktop profile, and `dshmarket` explicitly installs and updates packages in that profile.
+- Bundled Tencent's official `@tencent-connect/dsh-qqbot` 0.2.0 in the isolated `desktop` profile, enabling QQ direct-message and group-chat access to the desktop Harness.
+- Added a QQ Bot binding card to Extension Dock. First use now shows an auto-refreshing QR code in the desktop window with cancel, rebind, and unbind controls, without relying on a hidden terminal.
+- The QQ Bot plugin stays disabled until credentials exist, so terminal QR setup cannot delay Web UI startup. A successful scan enables the plugin and restarts DSH automatically.
+- AppSecret is encrypted through Electron `safeStorage` and Windows credential protection. It is supplied only to the DSH child environment and is never sent to renderer code, written to logs, or stored in plaintext in `cordis.patch.yml`.
 
 ### Verification
 
-- Electron end-to-end coverage switches the real title bar between light and dark styling and verifies that standard DSH dialogs begin below the title bar.
-- The real DSH Host integration test loads both plugin stores, checks the marketplace endpoint and store UI entry, applies QQ98, and verifies the desktop profile patch.
-- Packaged-payload verification continues to inspect every managed runtime package and all nine skin manifests and client bundles.
+- 53 desktop tests cover profile composition, encrypted credential boundaries, QR lifecycle, cancellation and unbinding, renderer-safe IPC payloads, runtime environment injection, and the real DSH Host.
+- Electron end-to-end verification requested a real QR code from Tencent's official Connector and confirmed that it renders and cancels correctly in Extension Dock without completing a binding or saving credentials.
+- Packaged-payload verification checks the official QQ Bot package and its runtime dependencies in addition to every managed desktop package, skin manifest, and client bundle.
 
 ### Download and verification
 
-Download `DeepSeek-Harness-Desktop-Setup-0.1.5-x64.exe` and verify it with `SHA256SUMS.txt` from the same GitHub Release. The built-in updater downloads only after user confirmation and asks again before installation and restart.
+Download `DeepSeek-Harness-Desktop-Setup-0.1.6-x64.exe` and verify it with `SHA256SUMS.txt` from the same GitHub Release. The built-in updater downloads only after user confirmation and asks again before installation and restart.
 
 ### Notice
 
-This is a community build and not an official DeepSeek distribution. It is not signed with a commercial code-signing certificate, so Windows SmartScreen may report an unknown publisher. Download only from this project's GitHub Release page and verify the SHA-256 checksum. Upgrading preserves the existing DSH home, desktop profile, pet state, and skin configuration.
+This is a community build and not an official DeepSeek or Tencent distribution. The QQ Bot plugin and QR Connector are official Tencent npm packages. The installer is not signed with a commercial code-signing certificate, so Windows SmartScreen may report an unknown publisher. Download only from this project's GitHub Release page and verify the SHA-256 checksum. Upgrading preserves the existing DSH home, desktop profile, pet state, skin configuration, and encrypted QQ Bot binding credentials.

--- a/docs/plans/2026-08-14-qqbot-desktop-adaptation-design.md
+++ b/docs/plans/2026-08-14-qqbot-desktop-adaptation-design.md
@@ -1,0 +1,39 @@
+# QQ Bot desktop adaptation design
+
+## Goal
+
+Ship `@tencent-connect/dsh-qqbot@0.2.0` as a protected desktop bundle and make its first-run QR binding usable without a visible terminal. The integration applies only to the isolated `desktop` profile and must not expose AppSecret to renderer code, logs, or `cordis.patch.yml`.
+
+## Runtime composition
+
+- Add the official QQ Bot bundle to the desktop package and managed profile packages.
+- Keep the bundle's `im-qqbot` row disabled while no desktop credential exists. This prevents the upstream plugin from entering its terminal-only QR setup during normal desktop startup.
+- Maintain a small marker-delimited QQ Bot section in the desktop profile patch. It contains only `disabled: true|false`; credentials never enter YAML.
+- Load encrypted credentials before constructing the DSH runtime controller and inject `QQBOT_APPID` and `QQBOT_SECRET` into the child environment through an environment provider.
+
+## Credential storage
+
+- Encrypt the complete credential JSON with Electron `safeStorage` and persist only the encrypted base64 payload under the app user-data directory.
+- Refuse to persist if OS encryption is unavailable.
+- Return only binding state and a masked AppID to renderer code.
+- On unbind, stop an active QR flow, remove the encrypted file, disable the profile row, clear the in-memory runtime environment, and restart DSH.
+
+## QR flow
+
+- Use the official connector's callback API with console rendering disabled.
+- Convert each QR URL to an in-memory PNG data URL in the Electron main process.
+- Forward QR refresh, success, cancellation, and failure events over a narrow IPC surface.
+- On success, encrypt credentials, enable the profile row, update the runtime environment, restart DSH, and report the resulting state.
+
+## UI
+
+- Add a protected QQ Bot binding card above the generic Cordis bundle list in Extension Dock.
+- Show unbound, waiting-for-scan, restarting, bound, and error states.
+- While scanning, render the QR image and expose cancel. When bound, show only the masked AppID and an explicit unbind action.
+
+## Verification
+
+- Unit-test credential encryption boundaries, managed profile patch preservation, QR event lifecycle, cancellation, and unbind.
+- Test IPC registration and renderer-safe payloads.
+- Extend profile composition and package verification to cover the official bundle.
+- Run the actual DSH host with QQ Bot disabled, then build and verify the unpacked application and the 0.1.6 NSIS installer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-web-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "DeepSeek Harness Web GUI 皮肤集合 + 主题库预览页（仿 Codex-Dream-Skin / DreamSkin.cc）。每个皮肤是符合官方标准（turtle-ui 式 setup）的独立可安装插件包。",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-web-ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "DeepSeek Harness Web GUI 皮肤集合 + 主题库预览页（仿 Codex-Dream-Skin / DreamSkin.cc）。每个皮肤是符合官方标准（turtle-ui 式 setup）的独立可安装插件包。",
   "scripts": {

--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -1,9 +1,9 @@
 import { installSettingsSection, settingsNamespace } from "@deepseek-ai/dsh-settings";
 import z from "schemastery";
-import { lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, statSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, realpathSync, renameSync, statSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
 //#region src/skin-switch.ts
 /**
 * In-process skin switching for the skin center — the official `dsh-skin use`
@@ -22,13 +22,18 @@ import { homedir } from "node:os";
 * dictionary, so adding a skin needs no code change here.
 * @module @linxin666/dsh-client-ui-skin-center/skin-switch
 */
-/** Repo layout: skin bundles live at packages/skins/<id>. */
-const SKINS_DIR$1 = fileURLToPath(new URL("../../../skins/", import.meta.url));
+/** Source checkout fallback; packaged builds discover skins from the active profile. */
+const REPO_SKINS_DIR = fileURLToPath(new URL("../../../skins/", import.meta.url));
 /** Managed patch-section delimiters (the CLI's SINGLE authority boundaries). */
 const MANAGED_START = "# --- dsh-skin managed (auto-generated; do not edit) ---";
 const MANAGED_END = "# --- end dsh-skin managed ---";
 /** The GUI profile this machine runs (dsh web); overridable via DSH_SKIN_PROFILE. */
-const DEFAULT_PROFILE = process.env.DSH_SKIN_PROFILE ?? "web";
+function defaultProfile() {
+	return process.env.DSH_SKIN_PROFILE ?? process.env.DSH_PROFILE ?? "web";
+}
+function defaultDshHome() {
+	return process.env.DSH_HOME ?? join(homedir(), ".dsh");
+}
 /**
 * Parse the switch-relevant fields of one skin.json. Returns null for
 * anything that is not a valid skin so it is simply skipped — never walking
@@ -37,7 +42,7 @@ const DEFAULT_PROFILE = process.env.DSH_SKIN_PROFILE ?? "web";
 */
 function readSkinMeta(dir) {
 	try {
-		const meta = JSON.parse(readFileSync(join(SKINS_DIR$1, dir, "skin.json"), "utf8"));
+		const meta = JSON.parse(readFileSync(join(dir, "skin.json"), "utf8"));
 		if (typeof meta !== "object" || meta === null) return null;
 		const record = meta;
 		if (typeof record.id !== "string" || !/^[a-z0-9-]+$/.test(record.id)) return null;
@@ -64,15 +69,26 @@ function readSkinMeta(dir) {
 * needs no code change here.
 * @returns skin id -> switch metadata.
 */
-function loadRegistry() {
+function loadRegistry(opts = {}) {
 	const out = {};
-	for (const dir of readdirSync(SKINS_DIR$1)) {
+	const dshHome = opts.dshHome ?? defaultDshHome();
+	const profile = opts.profile ?? defaultProfile();
+	const candidates = [];
+	const installedScope = join(dshHome, "profiles", profile, "node_modules", "@linxin666");
+	try {
+		for (const name of readdirSync(installedScope)) if (name.startsWith("dsh-client-ui-skin-")) candidates.push(join(installedScope, name));
+	} catch {}
+	if (opts.includeRepo !== false) try {
+		for (const name of readdirSync(REPO_SKINS_DIR)) candidates.push(join(REPO_SKINS_DIR, name));
+	} catch {}
+	for (const dir of candidates) {
 		const meta = readSkinMeta(dir);
 		if (meta === null || meta.wiring === void 0 || meta.package === void 0) continue;
+		if (out[meta.id] !== void 0) continue;
 		out[meta.id] = {
 			pkg: meta.package,
 			id: meta.wiring.id,
-			dir: join(SKINS_DIR$1, dir),
+			dir,
 			bundleWired: meta.wiring.bundleWired === true
 		};
 	}
@@ -156,10 +172,12 @@ function currentActive(patch, registry = loadRegistry()) {
 * @param home - home dir (defaults to the process HOME).
 * @param profile - profile name (defaults to DSH_SKIN_PROFILE or 'web').
 */
-function resolvePaths(home = homedir(), profile = DEFAULT_PROFILE) {
+function resolvePaths(home, profile) {
+	const dshHome = home === void 0 ? defaultDshHome() : join(home, ".dsh");
+	const activeProfile = profile ?? defaultProfile();
 	return {
-		patchPath: join(home, ".dsh", "cordis.patch.yml"),
-		profileModulesDir: join(home, ".dsh", "profiles", profile, "node_modules")
+		patchPath: join(dshHome, "profiles", activeProfile, "cordis.patch.yml"),
+		profileModulesDir: join(dshHome, "profiles", activeProfile, "node_modules")
 	};
 }
 function readPatch(patchPath) {
@@ -197,12 +215,20 @@ function ensureSymlink(entry, profileModulesDir) {
 		stat = lstatSync(target);
 	} catch {}
 	if (stat) {
-		if (!stat.isSymbolicLink()) throw new Error(`${target} exists and is not a symlink — refusing to touch it`);
+		try {
+			if (realpathSync(target) === realpathSync(entry.dir)) return false;
+		} catch {}
+		if (!stat.isSymbolicLink()) {
+			try {
+				if (JSON.parse(readFileSync(join(target, "package.json"), "utf8")).name === entry.pkg) return false;
+			} catch {}
+			throw new Error(`${target} exists and is not the selected skin package — refusing to touch it`);
+		}
 		if (readlinkSync(target) === entry.dir) return false;
 		unlinkSync(target);
 	}
 	mkdirSync(dirname(target), { recursive: true });
-	symlinkSync(entry.dir, target);
+	symlinkSync(entry.dir, target, process.platform === "win32" ? "junction" : "dir");
 	return true;
 }
 /** Windows/privilege code points where symlinkSync fails. */
@@ -236,9 +262,10 @@ function symlinkFriendly(caller, fn) {
 function checkInstalled(entry, profileModulesDir) {
 	let ok = false;
 	try {
-		ok = lstatSync(join(profileModulesDir, entry.pkg)).isSymbolicLink();
+		const target = join(profileModulesDir, entry.pkg);
+		ok = lstatSync(target).isDirectory() || lstatSync(target).isSymbolicLink();
 	} catch {}
-	return ok ? null : `${entry.pkg} 未安装到 profile；先用 dsh-skin install ${entry.id.replace(/^ui-skin-/, "")}（或 dsh plugin --profile ${DEFAULT_PROFILE} add ${entry.dir}）安装，否则加载会失败。`;
+	return ok ? null : `${entry.pkg} 未安装到 profile；先用 dsh-skin install ${entry.id.replace(/^ui-skin-/, "")}（或 dsh plugin --profile ${defaultProfile()} add ${entry.dir}）安装，否则加载会失败。`;
 }
 /**
 * Switch the active skin. Equivalent to `dsh-skin use <name>`:
@@ -435,29 +462,6 @@ function postRoute(path, run) {
 		}
 	};
 }
-/** Repo layout: skin bundles live at packages/skins/<id>/lib/client.js. */
-const SKINS_DIR = fileURLToPath(new URL("../../../skins/", import.meta.url));
-/**
-* Map skin id -> directory under packages/skins/, scanned from each
-* skin.json. The id is validated against this map (never used as a raw
-* path) so the bundle route cannot be walked off the skins tree.
-* @returns skin id -> directory name.
-*/
-function skinDirectories() {
-	const out = /* @__PURE__ */ new Map();
-	for (const dir of readdirSync(SKINS_DIR)) {
-		const metaFile = join(SKINS_DIR, dir, "skin.json");
-		if (!statSync(metaFile, { throwIfNoEntry: false })) continue;
-		let meta;
-		try {
-			meta = JSON.parse(readFileSync(metaFile, "utf8"));
-		} catch {
-			continue;
-		}
-		if (typeof meta.id === "string" && /^[a-z0-9-]+$/.test(meta.id)) out.set(meta.id, dir);
-	}
-	return out;
-}
 /**
 * The on-demand bundle route: serve packages/skins/<id>/lib/client.js as a
 * same-origin script. Try-on loads it through a script tag (the kernel's
@@ -491,15 +495,15 @@ function bundleRoute() {
 				return;
 			}
 			try {
-				const dir = skinDirectories().get(id);
-				if (dir === void 0) {
+				const entry = loadRegistry()[id];
+				if (entry === void 0) {
 					json(res, 404, {
 						ok: false,
 						error: "skin-not-found"
 					});
 					return;
 				}
-				const bundle = join(SKINS_DIR, dir, "lib", "client.js");
+				const bundle = join(entry.dir, "lib", "client.js");
 				if (!statSync(bundle, { throwIfNoEntry: false })) {
 					json(res, 404, {
 						ok: false,

--- a/packages/skins/skin-center/src/routes.ts
+++ b/packages/skins/skin-center/src/routes.ts
@@ -18,12 +18,11 @@
  * @module @linxin666/dsh-client-ui-skin-center/routes
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { join as joinPath } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
-import { currentSkin, useSkin } from './skin-switch.ts'
+import { currentSkin, loadRegistry, useSkin } from './skin-switch.ts'
 
 /** Browser-facing base path of the skin-center API. */
 export const SKIN_CENTER_API_PREFIX = '/api/skin-center'
@@ -165,31 +164,6 @@ export interface SkinCenterRoutesDeps {
   run?: (args: string[]) => Promise<string>
 }
 
-/** Repo layout: skin bundles live at packages/skins/<id>/lib/client.js. */
-const SKINS_DIR = fileURLToPath(new URL('../../../skins/', import.meta.url))
-
-/**
- * Map skin id -> directory under packages/skins/, scanned from each
- * skin.json. The id is validated against this map (never used as a raw
- * path) so the bundle route cannot be walked off the skins tree.
- * @returns skin id -> directory name.
- */
-function skinDirectories(): Map<string, string> {
-  const out = new Map<string, string>()
-  for (const dir of readdirSync(SKINS_DIR)) {
-    const metaFile = joinPath(SKINS_DIR, dir, 'skin.json')
-    if (!statSync(metaFile, { throwIfNoEntry: false })) continue
-    let meta: { id?: unknown }
-    try {
-      meta = JSON.parse(readFileSync(metaFile, 'utf8'))
-    } catch {
-      continue
-    }
-    if (typeof meta.id === 'string' && /^[a-z0-9-]+$/.test(meta.id)) out.set(meta.id, dir)
-  }
-  return out
-}
-
 /**
  * The on-demand bundle route: serve packages/skins/<id>/lib/client.js as a
  * same-origin script. Try-on loads it through a script tag (the kernel's
@@ -217,12 +191,12 @@ function bundleRoute(): WebRoute {
         return
       }
       try {
-        const dir = skinDirectories().get(id)
-        if (dir === undefined) {
+        const entry = loadRegistry()[id]
+        if (entry === undefined) {
           json(res, 404, { ok: false, error: 'skin-not-found' })
           return
         }
-        const bundle = joinPath(SKINS_DIR, dir, 'lib', 'client.js')
+        const bundle = joinPath(entry.dir, 'lib', 'client.js')
         if (!statSync(bundle, { throwIfNoEntry: false })) {
           json(res, 404, { ok: false, error: 'skin-bundle-missing' })
           return

--- a/packages/skins/skin-center/src/skin-switch.ts
+++ b/packages/skins/skin-center/src/skin-switch.ts
@@ -16,20 +16,26 @@
  * @module @linxin666/dsh-client-ui-skin-center/skin-switch
  */
 
-import { readdirSync, readFileSync, readlinkSync, lstatSync, mkdirSync, symlinkSync, unlinkSync, writeFileSync, renameSync } from 'node:fs'
+import { readdirSync, readFileSync, readlinkSync, lstatSync, mkdirSync, realpathSync, symlinkSync, unlinkSync, writeFileSync, renameSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join as joinPath } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-/** Repo layout: skin bundles live at packages/skins/<id>. */
-const SKINS_DIR = fileURLToPath(new URL('../../../skins/', import.meta.url))
+/** Source checkout fallback; packaged builds discover skins from the active profile. */
+const REPO_SKINS_DIR = fileURLToPath(new URL('../../../skins/', import.meta.url))
 
 /** Managed patch-section delimiters (the CLI's SINGLE authority boundaries). */
 export const MANAGED_START = '# --- dsh-skin managed (auto-generated; do not edit) ---'
 export const MANAGED_END = '# --- end dsh-skin managed ---'
 
 /** The GUI profile this machine runs (dsh web); overridable via DSH_SKIN_PROFILE. */
-const DEFAULT_PROFILE = process.env.DSH_SKIN_PROFILE ?? 'web'
+function defaultProfile(): string {
+  return process.env.DSH_SKIN_PROFILE ?? process.env.DSH_PROFILE ?? 'web'
+}
+
+function defaultDshHome(): string {
+  return process.env.DSH_HOME ?? joinPath(homedir(), '.dsh')
+}
 
 /** One skin's switch metadata, derived from its packages/skins/<id>/skin.json. */
 export interface SkinSwitchEntry {
@@ -51,7 +57,7 @@ export interface SkinSwitchEntry {
  */
 function readSkinMeta(dir: string): { id: string; package: string; wiring: { id: string; bundleWired: boolean } } | null {
   try {
-    const meta: unknown = JSON.parse(readFileSync(joinPath(SKINS_DIR, dir, 'skin.json'), 'utf8'))
+    const meta: unknown = JSON.parse(readFileSync(joinPath(dir, 'skin.json'), 'utf8'))
     if (typeof meta !== 'object' || meta === null) return null
     const record = meta as Record<string, unknown>
     if (typeof record.id !== 'string' || !/^[a-z0-9-]+$/.test(record.id)) return null
@@ -79,15 +85,30 @@ function readSkinMeta(dir: string): { id: string; package: string; wiring: { id:
  * needs no code change here.
  * @returns skin id -> switch metadata.
  */
-export function loadRegistry(): Record<string, SkinSwitchEntry> {
+export function loadRegistry(opts: { dshHome?: string; profile?: string; includeRepo?: boolean } = {}): Record<string, SkinSwitchEntry> {
   const out: Record<string, SkinSwitchEntry> = {}
-  for (const dir of readdirSync(SKINS_DIR)) {
+  const dshHome = opts.dshHome ?? defaultDshHome()
+  const profile = opts.profile ?? defaultProfile()
+  const candidates: string[] = []
+  const installedScope = joinPath(dshHome, 'profiles', profile, 'node_modules', '@linxin666')
+  try {
+    for (const name of readdirSync(installedScope)) {
+      if (name.startsWith('dsh-client-ui-skin-')) candidates.push(joinPath(installedScope, name))
+    }
+  } catch { /* profile may not exist outside DSH */ }
+  if (opts.includeRepo !== false) {
+    try {
+      for (const name of readdirSync(REPO_SKINS_DIR)) candidates.push(joinPath(REPO_SKINS_DIR, name))
+    } catch { /* packaged builds intentionally have no repo skins directory */ }
+  }
+  for (const dir of candidates) {
     const meta = readSkinMeta(dir)
     if (meta === null || meta.wiring === undefined || meta.package === undefined) continue
+    if (out[meta.id] !== undefined) continue
     out[meta.id] = {
       pkg: meta.package,
       id: meta.wiring.id,
-      dir: joinPath(SKINS_DIR, dir),
+      dir,
       bundleWired: meta.wiring.bundleWired === true,
     }
   }
@@ -189,7 +210,7 @@ export function currentActive(patch: string, registry: Record<string, SkinSwitch
 
 /** Layout of the DSH home + profile the CLI switches against. */
 export interface SkinSwitchPaths {
-  /** ~/.dsh/cordis.patch.yml */
+  /** $DSH_HOME/profiles/<profile>/cordis.patch.yml */
   patchPath: string
   /** ~/.dsh/profiles/<profile>/node_modules */
   profileModulesDir: string
@@ -201,10 +222,12 @@ export interface SkinSwitchPaths {
  * @param home - home dir (defaults to the process HOME).
  * @param profile - profile name (defaults to DSH_SKIN_PROFILE or 'web').
  */
-export function resolvePaths(home: string = homedir(), profile: string = DEFAULT_PROFILE): SkinSwitchPaths {
+export function resolvePaths(home?: string, profile?: string): SkinSwitchPaths {
+  const dshHome = home === undefined ? defaultDshHome() : joinPath(home, '.dsh')
+  const activeProfile = profile ?? defaultProfile()
   return {
-    patchPath: joinPath(home, '.dsh', 'cordis.patch.yml'),
-    profileModulesDir: joinPath(home, '.dsh', 'profiles', profile, 'node_modules'),
+    patchPath: joinPath(dshHome, 'profiles', activeProfile, 'cordis.patch.yml'),
+    profileModulesDir: joinPath(dshHome, 'profiles', activeProfile, 'node_modules'),
   }
 }
 
@@ -245,8 +268,15 @@ function ensureSymlink(entry: SkinSwitchEntry, profileModulesDir: string): boole
   let stat: ReturnType<typeof lstatSync> | null = null
   try { stat = lstatSync(target) } catch { /* absent */ }
   if (stat) {
+    try {
+      if (realpathSync(target) === realpathSync(entry.dir)) return false
+    } catch { /* inspect the target type below */ }
     if (!stat.isSymbolicLink()) {
-      throw new Error(`${target} exists and is not a symlink — refusing to touch it`)
+      try {
+        const manifest = JSON.parse(readFileSync(joinPath(target, 'package.json'), 'utf8')) as { name?: unknown }
+        if (manifest.name === entry.pkg) return false
+      } catch { /* unmanaged target */ }
+      throw new Error(`${target} exists and is not the selected skin package — refusing to touch it`)
     }
     const current = readlinkSync(target)
     if (current === entry.dir) return false
@@ -255,7 +285,7 @@ function ensureSymlink(entry: SkinSwitchEntry, profileModulesDir: string): boole
   // The link's parent scoped dir may not exist on a fresh machine (the
   // profiles/node_modules tree is created incrementally).
   mkdirSync(dirname(target), { recursive: true })
-  symlinkSync(entry.dir, target)
+  symlinkSync(entry.dir, target, process.platform === 'win32' ? 'junction' : 'dir')
   return true
 }
 
@@ -292,9 +322,10 @@ function symlinkFriendly<T>(caller: string, fn: () => T): T {
 function checkInstalled(entry: SkinSwitchEntry, profileModulesDir: string): string | null {
   let ok = false
   try {
-    ok = lstatSync(joinPath(profileModulesDir, entry.pkg)).isSymbolicLink()
+    const target = joinPath(profileModulesDir, entry.pkg)
+    ok = lstatSync(target).isDirectory() || lstatSync(target).isSymbolicLink()
   } catch { /* absent */ }
-  return ok ? null : `${entry.pkg} 未安装到 profile；先用 dsh-skin install ${entry.id.replace(/^ui-skin-/, '')}（或 dsh plugin --profile ${DEFAULT_PROFILE} add ${entry.dir}）安装，否则加载会失败。`
+  return ok ? null : `${entry.pkg} 未安装到 profile；先用 dsh-skin install ${entry.id.replace(/^ui-skin-/, '')}（或 dsh plugin --profile ${defaultProfile()} add ${entry.dir}）安装，否则加载会失败。`
 }
 
 /**

--- a/packages/skins/skin-center/tests/skin-switch.spec.ts
+++ b/packages/skins/skin-center/tests/skin-switch.spec.ts
@@ -34,13 +34,14 @@ afterAll(() => {
 function fakeHome(): string {
   home = mkdtempSync(join(tmpdir(), 'skin-switch-test-'))
   mkdirSync(join(home, '.dsh'), { recursive: true })
+  mkdirSync(join(home, '.dsh', 'profiles', 'web'), { recursive: true })
   // Mirror the CLI test: the profile symlink target is the real repo skin dir.
   mkdirSync(join(home, 'code', 'dsh-web-ui', 'packages', 'skins'), { recursive: true })
   return home
 }
 
 function patchPath(h: string): string {
-  return join(h, '.dsh', 'cordis.patch.yml')
+  return join(h, '.dsh', 'profiles', 'web', 'cordis.patch.yml')
 }
 
 /** A minimal registry for pure-function tests (deterministic, no disk reads). */
@@ -165,5 +166,37 @@ describe('useSkin / currentSkin against a throwaway HOME', () => {
   it('useSkin on an unknown skin rejects like the CLI', () => {
     const h = fakeHome()
     expect(() => useSkin('nope', { home: h })).toThrow(/unknown skin "nope"/)
+  })
+
+  it('defaults to DSH_HOME and the desktop-selected profile', () => {
+    const h = fakeHome()
+    const previousHome = process.env.DSH_HOME
+    const previousProfile = process.env.DSH_SKIN_PROFILE
+    process.env.DSH_HOME = join(h, '.dsh')
+    process.env.DSH_SKIN_PROFILE = 'desktop'
+    try {
+      expect(resolvePaths()).toEqual({
+        patchPath: join(h, '.dsh', 'profiles', 'desktop', 'cordis.patch.yml'),
+        profileModulesDir: join(h, '.dsh', 'profiles', 'desktop', 'node_modules'),
+      })
+    } finally {
+      if (previousHome === undefined) delete process.env.DSH_HOME
+      else process.env.DSH_HOME = previousHome
+      if (previousProfile === undefined) delete process.env.DSH_SKIN_PROFILE
+      else process.env.DSH_SKIN_PROFILE = previousProfile
+    }
+  })
+
+  it('loads registry metadata from installed profile packages', () => {
+    const h = fakeHome()
+    const packageDir = join(h, '.dsh', 'profiles', 'desktop', 'node_modules', '@linxin666', 'dsh-client-ui-skin-fixture')
+    mkdirSync(packageDir, { recursive: true })
+    writeFileSync(join(packageDir, 'skin.json'), JSON.stringify({
+      id: 'fixture',
+      package: '@linxin666/dsh-client-ui-skin-fixture',
+      wiring: { id: 'ui-skin-fixture', bundleWired: false },
+    }))
+    const registry = loadRegistry({ dshHome: join(h, '.dsh'), profile: 'desktop', includeRepo: false })
+    expect(registry.fixture?.dir).toBe(packageDir)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       '@linxin666/dsh-web-ui-all':
         specifier: workspace:*
         version: link:../../packages/dsh-web-ui-all
+      '@tencent-connect/dsh-qqbot':
+        specifier: 0.2.0
+        version: 0.2.0(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/schemastery@3.18.1)(@tencent-connect/qqbot-connector@1.2.0)
+      '@tencent-connect/qqbot-connector':
+        specifier: 1.2.0
+        version: 1.2.0
       dsh-plugin-hub:
         specifier: 0.1.0
         version: 0.1.0(e178a92a93669a36c2df5582dfbd6b78)
@@ -101,6 +107,9 @@ importers:
       pnpm:
         specifier: 11.21.0
         version: 11.21.0
+      qrcode:
+        specifier: 1.5.4
+        version: 1.5.4
       yaml:
         specifier: 2.8.1
         version: 2.8.1
@@ -4313,6 +4322,32 @@ packages:
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
+  '@tencent-connect/dsh-qqbot@0.2.0':
+    resolution: {integrity: sha512-U7GnRQQDjzvIXfdxo/6eoGPGcolZRxX3GaTM3B6uz/8FskFmmtBUXTMMEkUY+qAjg1sdFoBPIRCy3QdkioT3EQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': '>=4.0.1'
+      '@deepseek-ai/dsh-agent': '>=0.1.0-rc.6'
+      '@deepseek-ai/dsh-llm': '>=0.1.0-rc.6'
+      '@deepseek-ai/dsh-session': '>=0.1.0-rc.6'
+      '@deepseek-ai/schemastery': '>=3.18.1'
+      '@tencent-connect/qqbot-connector': 1.2.0
+
+  '@tencent-connect/qqbot-connector@1.2.0':
+    resolution: {integrity: sha512-FAOUCvgxP4M9UiYbHrtVgJ7BavSlh1CHJPjeEQuTAkP9MZ91lX4yATqv6I/lB9yp15nVq+G2DaGSSJwQTSoSsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@tencent-connect/qqbot-nodejs@1.0.4':
+    resolution: {integrity: sha512-gU5HySLplczZXMUjM7NtiUACY7YfX9YlI/R9PKzCLMgLmHvwsX9L2sitsrYPMentGUr9b8NLfSaSTsndF77NBA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      mpg123-decoder: ^1.0.3
+      silk-wasm: ^3.7.1
+    peerDependenciesMeta:
+      mpg123-decoder:
+        optional: true
+      silk-wasm:
+        optional: true
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -4725,6 +4760,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -4775,6 +4814,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4897,6 +4939,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -4951,6 +4997,9 @@ packages:
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
@@ -5174,6 +5223,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
@@ -5668,6 +5721,10 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
@@ -6070,13 +6127,25 @@ packages:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -6090,6 +6159,10 @@ packages:
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -6141,6 +6214,10 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   pnpm@11.21.0:
     resolution: {integrity: sha512-UhcFvOaJkk6scvWjWHEi82JonvZXHlW6gAdv1jfBETLs/62ib61Op5xIW/3b/T1aKlsFgFp36JPeceyKbMo7sQ==}
@@ -6198,10 +6275,19 @@ packages:
     resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
     engines: {node: '>=16.0.0'}
 
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
+
   qrcode.react@4.2.0:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -6265,6 +6351,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
@@ -6393,6 +6482,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -6963,6 +7055,9 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -6982,6 +7077,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -7013,6 +7112,9 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -7034,9 +7136,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
@@ -11117,6 +11227,33 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.7': {}
 
+  '@tencent-connect/dsh-qqbot@0.2.0(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/schemastery@3.18.1)(@tencent-connect/qqbot-connector@1.2.0)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/schemastery': 3.18.1
+      '@tencent-connect/qqbot-connector': 1.2.0
+      '@tencent-connect/qqbot-nodejs': 1.0.4
+      js-yaml: 4.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - mpg123-decoder
+      - silk-wasm
+      - utf-8-validate
+
+  '@tencent-connect/qqbot-connector@1.2.0':
+    dependencies:
+      qrcode-terminal: 0.12.0
+
+  '@tencent-connect/qqbot-nodejs@1.0.4':
+    dependencies:
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -11606,6 +11743,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  camelcase@5.3.1: {}
+
   ccount@2.0.1: {}
 
   chai@5.3.3:
@@ -11646,6 +11785,12 @@ snapshots:
   ci-info@4.3.1: {}
 
   ci-info@4.4.0: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
@@ -11748,6 +11893,8 @@ snapshots:
     optionalDependencies:
       supports-color: 7.2.0
 
+  decamelize@1.2.0: {}
+
   decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
@@ -11794,6 +11941,8 @@ snapshots:
       dequal: 2.0.3
 
   diff@9.0.0: {}
+
+  dijkstrajs@1.0.3: {}
 
   dir-compare@4.2.0:
     dependencies:
@@ -12079,6 +12228,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   form-data@4.0.6:
     dependencies:
@@ -12632,6 +12786,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   lodash.escaperegexp@4.1.2: {}
 
   lodash.isequal@4.5.0: {}
@@ -13183,14 +13341,24 @@ snapshots:
 
   p-cancelable@2.1.1: {}
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-try@2.2.0: {}
 
   parse5@7.3.0:
     dependencies:
@@ -13203,6 +13371,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   partial-json@0.1.7: {}
+
+  path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -13244,6 +13414,8 @@ snapshots:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pngjs@5.0.0: {}
 
   pnpm@11.21.0: {}
 
@@ -13310,9 +13482,17 @@ snapshots:
 
   pvutils@1.2.0: {}
 
+  qrcode-terminal@0.12.0: {}
+
   qrcode.react@4.2.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   qs@6.15.3:
     dependencies:
@@ -13377,6 +13557,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   resedit@1.7.2:
     dependencies:
@@ -13604,6 +13786,8 @@ snapshots:
       send: 1.2.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -14339,6 +14523,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -14356,6 +14542,12 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -14372,6 +14564,8 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@4.0.0: {}
@@ -14382,7 +14576,26 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       '@linxin666/dsh-web-ui-all':
         specifier: workspace:*
         version: link:../../packages/dsh-web-ui-all
+      dsh-plugin-hub:
+        specifier: 0.1.0
+        version: 0.1.0(e178a92a93669a36c2df5582dfbd6b78)
+      dshmarket:
+        specifier: 1.0.3
+        version: 1.0.3(@deepseek-ai/cordis@4.0.1)
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@7.2.0)
@@ -4963,6 +4969,27 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dsh-plugin-hub@0.1.0:
+    resolution: {integrity: sha512-QRBvaqMP2xvAzQTyCVwFe3K/xNdhiE0YFjnCIPxth2SeSFnXl0EwRPgzBrnMp4u+secUy4+pwb2D1H8JD1Lhlg==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/cordis-plugin-loader': '>=1.0.2 <2.0.0'
+      '@deepseek-ai/dsh-api-gateway': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-client-locale': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-client-runtime': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-client-ui-settings': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-client-ui-settings-general': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-client-ui-sidebar': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-client-ui-slots': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+      react: '>=18.2.0 <20.0.0'
+
+  dshmarket@1.0.3:
+    resolution: {integrity: sha512-IMkcPzPNalxkIr/b5PNeqxOI/kmDlruAs3H7fuNl0h3F9rqWSvhSJqS5hO5JMBh167MYtFa8q+vnZbVnVSDqdA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -9418,7 +9445,7 @@ snapshots:
       '@deepseek-ai/dsh-skill': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
       chokidar: 5.0.0
-      yaml: 2.9.0
+      yaml: 2.8.1
 
   '@deepseek-ai/dsh-skill@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
@@ -11790,6 +11817,26 @@ snapshots:
       dotenv: 16.6.1
 
   dotenv@16.6.1: {}
+
+  dsh-plugin-hub@0.1.0(e178a92a93669a36c2df5582dfbd6b78):
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)(node-addon-require-builtin@0.1.4)
+      '@deepseek-ai/dsh-api-gateway': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.0-rc.6)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-registry@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-client-locale': 0.1.0-rc.6(a3add67140921a898dbf2076d6097374)
+      '@deepseek-ai/dsh-client-runtime': 0.1.0-rc.6(9b9cc316d8840c207092351c825bdfdb)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.0-rc.6(963f21f11cddd09def26a2473cddd8c5))(@deepseek-ai/dsh-client-connection@0.1.0-rc.6)(@deepseek-ai/dsh-client-runtime@0.1.0-rc.6(9b9cc316d8840c207092351c825bdfdb))(@deepseek-ai/dsh-client-schema-form@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-ui-slots@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))(react@18.3.1)
+      '@deepseek-ai/dsh-client-ui-settings-general': 0.1.0-rc.6(7990f3f1b29c91ceb46180079ddc4289)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.0-rc.6(a3add67140921a898dbf2076d6097374))(@deepseek-ai/dsh-client-runtime@0.1.0-rc.6(9b9cc316d8840c207092351c825bdfdb))(@deepseek-ai/dsh-client-ui-primitives@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(supports-color@7.2.0))(@deepseek-ai/dsh-client-ui-slots@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
+      '@deepseek-ai/dsh-client-ui-slots': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      react: 18.3.1
+      yaml: 2.9.0
+      zod: 4.4.3
+
+  dshmarket@1.0.3(@deepseek-ai/cordis@4.0.1):
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
 
   dts-resolver@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,9 @@ allowBuilds:
   ssh2: true
 
 minimumReleaseAgeExclude:
+  - '@tencent-connect/dsh-qqbot@0.2.0'
+  - '@tencent-connect/qqbot-connector@1.2.0'
+  - '@tencent-connect/qqbot-nodejs@1.0.4'
   - '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.6'
   - '@deepseek-ai/dsh-agent@0.1.0-rc.6'
   - '@deepseek-ai/dsh-api-remotes@0.1.0-rc.6'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -222,3 +222,5 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-spill@0.1.0-rc.6'
   - '@deepseek-ai/dsh-subagent-in-process-driver@0.1.0-rc.6'
   - '@deepseek-ai/dsh-workflow@0.1.0-rc.6'
+  - dsh-plugin-hub@0.1.0
+  - dshmarket@1.0.3


### PR DESCRIPTION
## What changed

- fix light/dark native title-bar synchronization and keep full-screen dialogs below the desktop caption area
- restore packaged skin discovery and desktop-profile skin persistence
- bundle dshmarket 1.0.3 and dsh-plugin-hub 0.1.0 in the managed desktop profile
- bundle Tencent's official @tencent-connect/dsh-qqbot 0.2.0
- add an Extension Dock flow for QR binding, refresh, cancellation, rebinding, and unbinding
- encrypt QQ Bot credentials with Electron safeStorage and inject them only into the DSH child environment
- keep QQ Bot disabled until credentials exist so its terminal-only upstream setup cannot block desktop startup
- bump the desktop release to 0.1.6 and update bilingual release notes

## Why

Desktop users reported theme chrome defects, missing packaged skins and plugin stores, and no usable desktop path for the official QQ Bot plugin. The upstream QQ Bot first-run flow prints a QR code to a terminal, but the packaged desktop runtime runs in a hidden child process. This change adapts the official Connector callback API to a renderer-safe desktop flow.

## Impact

Users can bind QQ private and group chats from Extension Dock without editing YAML or exposing AppSecret. Existing desktop profiles, community bundles, skins, pets, and settings remain preserved.

## Validation

- 53 desktop tests passed
- real Tencent Connector QR code rendered and canceled in Electron without completing a binding
- real DSH Host integration passed
- 50 packaged runtime packages verified
- packaged Electron startup and window-chrome E2E passed
- 0.1.6 NSIS installer built locally