### PR TITLE
fix(dsh-desktop-compat): drop bare empty YAML list when writing skin state

### DIFF
--- a/packages/dsh-desktop-compat/lib/index.js
+++ b/packages/dsh-desktop-compat/lib/index.js
@@ -65,8 +65,7 @@ function appendDisabledRows(text, ids) {
 }
 function replaceSection(text, section) {
 	const bounds = sectionBounds(text);
-	const rawOutside = bounds === null ? text.trim() : `${text.slice(0, bounds.start)}${text.slice(bounds.end)}`.trim();
-	const outside = rawOutside === "[]" ? "" : rawOutside;
+	const outside = (bounds === null ? text.trim() : `${text.slice(0, bounds.start)}${text.slice(bounds.end)}`.trim()).split(/\r?\n/u).filter((line) => !/^[ \t]*\[\]$/u.test(line)).join("\n").trim();
 	return outside ? `${outside}\n\n${section}\n` : `${section}\n`;
 }
 function writeAtomic(path, content) {

--- a/packages/dsh-desktop-compat/src/skin-state.ts
+++ b/packages/dsh-desktop-compat/src/skin-state.ts
@@ -81,7 +81,17 @@ function replaceSection(text: string, section: string): string {
   const rawOutside = bounds === null
     ? text.trim()
     : `${text.slice(0, bounds.start)}${text.slice(bounds.end)}`.trim()
-  const outside = rawOutside === '[]' ? '' : rawOutside
+  // A `[]` empty YAML list is a placeholder left by earlier cleanups or
+  // other tools. It is not a patch the user owns: keep any surrounding
+  // comments but drop the bare list so the managed section stays the single
+  // root value of the file (otherwise the file holds two YAML documents and
+  // dsh fails to parse it).
+  const withoutEmptyList = rawOutside
+    .split(/\r?\n/u)
+    .filter(line => !/^[ \t]*\[\]$/u.test(line))
+    .join('\n')
+    .trim()
+  const outside = withoutEmptyList
   return outside ? `${outside}\n\n${section}\n` : `${section}\n`
 }
 

--- a/packages/dsh-desktop-compat/tests/skin-state.spec.ts
+++ b/packages/dsh-desktop-compat/tests/skin-state.spec.ts
@@ -83,6 +83,36 @@ describe('desktop skin state', () => {
     expect(content).toContain('- id: liquid-glass\n  disabled: true')
   })
 
+  it('drops a bare empty list even when comments surround it', () => {
+    const { patch, store } = fixture()
+    writeFileSync(
+      patch,
+      '# cleaned by an earlier tool\n# keep this note\n[]\n',
+    )
+
+    store.migrateLegacy(['dsh-liquid-glass'], [])
+
+    const content = readFileSync(patch, 'utf8')
+    expect(content).not.toContain('[]')
+    expect(content).toContain('# cleaned by an earlier tool')
+    expect(content).toContain('# keep this note')
+    expect(content).toContain('- id: liquid-glass\n  disabled: true')
+    // The managed section must be the only root value: comments are fine,
+    // but a second YAML document (the bare `[]`) must not survive.
+    expect(content).toMatch(/^\S/u)
+  })
+
+  it('preserves unrelated non-empty outside content', () => {
+    const { patch, store } = fixture()
+    writeFileSync(patch, '- id: retained\n  disabled: false\n')
+
+    store.activateBundleTheme('dsh-liquid-glass', ['dsh-liquid-glass', 'dsh-solarized'], [])
+
+    const content = readFileSync(patch, 'utf8')
+    expect(content).toContain('- id: retained\n  disabled: false')
+    expect(content).toContain('- id: liquid-glass\n  disabled: false')
+  })
+
   it('refuses to persist a non-bundle skin through the market channel', () => {
     const { store } = fixture()
     expect(() => store.activateBundleTheme('@linxin666/dsh-ui-skin-qq98', [], [])).toThrow('not wired through the active profile')


### PR DESCRIPTION
## 摘要（Summary）

修复 `replaceSection` 在 `packages/dsh-desktop-compat/src/skin-state.ts` 中的问题：它只在外部文本恰好等于 `[]` 时才移除空 YAML 列表占位符。当清理工具在空列表周围留下注释（如 `# cleaned...` 加 `[]`）时，裸 `[]` 幸存并与 managed skin 区块拼接，产生包含两个 YAML 根值的 `cordis.patch.yml`，导致 `dsh` 解析失败（遇到流结尾或需要文档分隔符），所有 profile（包括官方 `dsh web`）无法启动。已在 Windows 10 + Desktop 2.3.0 切换皮肤后复现。

## 受影响包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 参与编写或修改了部分代码修改
- 使用的 AI 模型： DeepSeek
- 使用的编码 Agent 工具： DeepSeek Harness

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm vitest run packages/dsh-desktop-compat/tests/skin-state.spec.ts
pnpm --filter dsh-desktop-compat run build
```

结果摘要：

7 个测试全部通过（含 2 个新增测试：带注释的裸 `[]` 被剥离、非空外部内容被保留）；lib/index.js 已用最新源码重新构建。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，行为已在单元测试中验证，无用户可见界面变化）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅使用官方 NPM SDK（`@deepseek-ai/*`）开发
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`
- [x] 新包目录使用 `dsh-` 前缀（如有新增）
- [x] 本次新增 / 修改的文件不含任何 emoji 字符
- [x] 修改 README 时同步维护中英双语（README.md / README.zh.md / README.i18n.yaml）
