### PR TITLE
fix(installer): keep cleanup script ASCII-safe

### DIFF
--- a/apps/dsh-desktop/build/cleanup-stale-processes.ps1
+++ b/apps/dsh-desktop/build/cleanup-stale-processes.ps1
@@ -502,7 +502,7 @@ namespace DshInstaller
         ) -WindowStyle Hidden -PassThru)
       } catch {
         $script:receiptProtocolFailed = $true
-        if ($_.Exception.Message -match '(?i)access.*denied|permission|拒绝访问') {
+        if ($_.Exception.Message -match '(?i)access.*denied|permission|\u62D2\u7EDD\u8BBF\u95EE') {
           $script:permissionDenied = $true
         }
         Write-Output "receipt-launch-error pid=$($runningMain.ProcessId): $($_.Exception.Message)"
@@ -581,7 +581,7 @@ namespace DshInstaller
       try {
         Stop-Process -Id $target.ProcessId -Force -ErrorAction Stop
       } catch {
-        if ($_.Exception.Message -match '(?i)access.*denied|permission|拒绝访问') {
+        if ($_.Exception.Message -match '(?i)access.*denied|permission|\u62D2\u7EDD\u8BBF\u95EE') {
           $script:permissionDenied = $true
         }
         Write-Output "stop-error pid=$($target.ProcessId): $($_.Exception.Message)"

--- a/apps/dsh-desktop/test/installer-cleanup.test.mjs
+++ b/apps/dsh-desktop/test/installer-cleanup.test.mjs
@@ -123,6 +123,8 @@ test('NSIS preflight cleans only stale processes owned by the previous install',
   assert.match(cleanup, /\$selfPid/u)
   assert.match(cleanup, /IndexOf\(\$root, \$comparison\)/u)
   assert.match(cleanup, /Get-CommandLineVariants/u)
+  assert.match(cleanup, /\\u62D2\\u7EDD\\u8BBF\\u95EE/u)
+  assert.doesNotMatch(cleanup, /[^\x00-\x7F]/u)
   assert.match(cleanup, /FromBase64String/u)
   assert.match(cleanup, /\[System\.Text\.Encoding\]::Unicode/u)
   assert.doesNotMatch(cleanup, /\.MainModule|\$process\.Path/u)


### PR DESCRIPTION
## 摘要（Summary）

修复英文区域 Windows PowerShell 5.1 无法解析安装清理脚本的问题。将权限错误匹配中的中文文字改为等价 Unicode 转义，并增加纯 ASCII 回归检查，避免 2.4.0 安装/自动更新失败。

## 涉及包（Affected Packages）

- [x] 其他（DeepSeek Harness Desktop 安装器）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

`git fetch desktop main`

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本次未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本次未改 README）。

## 贡献者版权声明（Contributor Copyright）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
powershell.exe -NoProfile -NonInteractive # PowerShell 5.1 Parser::ParseFile
node --test apps/dsh-desktop/test/installer-cleanup.test.mjs
pnpm verify
```

结果摘要：PowerShell 5.1 解析通过；安装清理专项 5/5；完整验证全部通过（Desktop 261/261、SSH 93 passed + 1 skipped、Task Board 147/147、scripts 109/109）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（安装器编码兼容性修复，无界面变化）。