### PR TITLE
fix(packaging): restore directory picker runtime peer

### DIFF
--- a/apps/dsh-desktop/package.json
+++ b/apps/dsh-desktop/package.json
@@ -50,6 +50,7 @@
     "@deepseek-ai/dsh-code-runtime": "0.1.0-rc.7",
     "@deepseek-ai/dsh-compaction": "0.1.0-rc.7",
     "@deepseek-ai/dsh-fs": "0.1.0-rc.7",
+    "@deepseek-ai/dsh-host-directory-picker": "0.1.0-rc.7",
     "@deepseek-ai/dsh-host-directory-picker-browse": "0.1.0-rc.7",
     "@deepseek-ai/dsh-host-webserver": "0.1.0-rc.7",
     "@deepseek-ai/dsh-llm": "0.1.0-rc.7",

--- a/apps/dsh-desktop/runtime-support/known-good.json
+++ b/apps/dsh-desktop/runtime-support/known-good.json
@@ -26,7 +26,7 @@
     "peerDependencies": {}
   },
   "lockfile": {
-    "sha256": "0ad4191004722b095725bc1cdf6ae52d909bb6adfaff3c7683a1fb1420fc74f8"
+    "sha256": "8d190e3ef5a5ca394b23673acda0c66b7de06432cd1dfc6c324cf0392a1745a9"
   },
   "provider": {
     "providerId": "dsh-cli-provider-v1",

--- a/apps/dsh-desktop/scripts/after-pack.cjs
+++ b/apps/dsh-desktop/scripts/after-pack.cjs
@@ -8,6 +8,7 @@ const REQUIRED_PACKAGED_PEERS = Object.freeze([
   '@deepseek-ai/dsh-atomic-write',
   '@deepseek-ai/dsh-attachment',
   '@deepseek-ai/dsh-brand',
+  '@deepseek-ai/dsh-host-directory-picker',
   '@deepseek-ai/dsh-host-webserver',
   '@deepseek-ai/dsh-sandbox-policy',
   '@deepseek-ai/dsh-settings',

--- a/apps/dsh-desktop/scripts/verify-package.mjs
+++ b/apps/dsh-desktop/scripts/verify-package.mjs
@@ -20,6 +20,7 @@ const resources = resolve(resourcesArgument || join(appDir, 'dist', 'win-unpacke
 const unpackedModules = join(resources, 'app.asar.unpacked', 'node_modules')
 const requiredPackages = [
   ...DSH_BOOT_RUNTIME_PACKAGES,
+  '@deepseek-ai/dsh-host-directory-picker',
   'electron-updater',
   'fflate',
   'pnpm',

--- a/apps/dsh-desktop/test/after-pack.test.mjs
+++ b/apps/dsh-desktop/test/after-pack.test.mjs
@@ -97,6 +97,7 @@ test('release recovery restores pnpm peer snapshots omitted by electron-builder'
       '@deepseek-ai/dsh-atomic-write',
       '@deepseek-ai/dsh-attachment',
       '@deepseek-ai/dsh-brand',
+      '@deepseek-ai/dsh-host-directory-picker',
       '@deepseek-ai/dsh-host-webserver',
       '@deepseek-ai/dsh-sandbox-policy',
       '@deepseek-ai/dsh-settings',

--- a/apps/dsh-desktop/test/runtime-integrity.test.mjs
+++ b/apps/dsh-desktop/test/runtime-integrity.test.mjs
@@ -35,6 +35,11 @@ test('desktop directly declares the telemetry package required during bootstrap'
   assert.equal(manifest.dependencies['@deepseek-ai/dsh-session-telemetry-otel'], '0.1.0-rc.7')
 })
 
+test('desktop directly declares the directory-picker host imported by the browse implementation', async () => {
+  const manifest = JSON.parse(await readFile(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'))
+  assert.equal(manifest.dependencies['@deepseek-ai/dsh-host-directory-picker'], '0.1.0-rc.7')
+})
+
 test('runtime integrity reports an incomplete installation and recommends reinstalling', async () => {
   const modulesRoot = await mkdtemp(join(tmpdir(), 'dsh-runtime-integrity-'))
   try {
@@ -63,6 +68,7 @@ test('package verification consumes the shared critical runtime file contract', 
   const source = await readFile(fileURLToPath(new URL('../scripts/verify-package.mjs', import.meta.url)), 'utf8')
   assert.match(source, /CRITICAL_RUNTIME_FILES/u)
   assert.match(source, /for \(const relativePath of CRITICAL_RUNTIME_FILES\)/u)
+  assert.match(source, /'@deepseek-ai\/dsh-host-directory-picker'/u)
   assert.match(source, /packaged SSH client eagerly bundles xterm/u)
   assert.match(source, /'@xterm', 'xterm', 'lib', 'xterm\.js'/u)
 })

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.json
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "desktopVersion": "2.7.0",
   "upstreamVersion": "0.1.0-rc.7",
-  "lockfileSha256": "0ad4191004722b095725bc1cdf6ae52d909bb6adfaff3c7683a1fb1420fc74f8",
+  "lockfileSha256": "8d190e3ef5a5ca394b23673acda0c66b7de06432cd1dfc6c324cf0392a1745a9",
   "policy": {
     "controlledImportPrefixes": [
       "apps/dsh-desktop/src/runtime-provider.mjs",

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.md
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.md
@@ -4,7 +4,7 @@ Authoritative Desktop version: 2.7.0.
 
 Stable DSH package version: 0.1.0-rc.7.
 
-Lockfile SHA-256: `0ad4191004722b095725bc1cdf6ae52d909bb6adfaff3c7683a1fb1420fc74f8`.
+Lockfile SHA-256: `8d190e3ef5a5ca394b23673acda0c66b7de06432cd1dfc6c324cf0392a1745a9`.
 
 Capability discovery is compatibility evidence only. Renderer surface identity, channel allowlists, and argument validation remain the authorization boundary.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@deepseek-ai/dsh-fs':
         specifier: 0.1.0-rc.7
         version: 0.1.0-rc.7(7991753c264b1d907549a3df5a6ef9ed)
+      '@deepseek-ai/dsh-host-directory-picker':
+        specifier: 0.1.0-rc.7
+        version: 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-browse':
         specifier: 0.1.0-rc.7
         version: 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
@@ -8413,7 +8416,7 @@ snapshots:
   '@deepseek-ai/dsh-api-gateway@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.0-rc.7)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-registry@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-connection': 0.1.0-rc.7(18ff0c05ab41670b8daa2e2e166479db)
+      '@deepseek-ai/dsh-client-connection': 0.1.0-rc.7(2f10e3fb58d0d825de6c330674be43fd)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-registry': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))


### PR DESCRIPTION
## 摘要（Summary）

修复已失败的 `desktop-v2.7.0` Windows 发布包：Directory Picker Browse 已被打包，但其运行时导入的 `@deepseek-ai/dsh-host-directory-picker` 被 electron-builder 的 peer snapshot 收集遗漏，导致打包后的目录选择器 E2E 在发布资产上传前失败。

本 PR 显式锁定该 rc.7 依赖，并把它纳入 after-pack 恢复和安装包验证。Desktop 版本仍为 2.7.0；此前标签工作流未创建任何 GitHub Release 或资产。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`apps/dsh-desktop` 打包、运行时完整性和发布验证

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch desktop main --tags --prune
git switch -c codex/desktop-v2.7.0-package-fix desktop/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

GPT-5.6

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README）。

## 贡献者版权声明（Contributor Copyright）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install --frozen-lockfile
node --test apps/dsh-desktop/test/after-pack.test.mjs apps/dsh-desktop/test/runtime-integrity.test.mjs
pnpm desktop:pack
pnpm --filter @deepseek-ai/dsh-desktop pack:verify
pnpm --filter @deepseek-ai/dsh-desktop pack:smoke
$env:DSH_DESKTOP_E2E_EXECUTABLE=(Resolve-Path 'apps/dsh-desktop/dist/win-unpacked/DeepSeek Harness Desktop.exe').Path
pnpm --filter @deepseek-ai/dsh-desktop test:directory-picker:e2e
git diff --check
```

结果摘要：

冻结安装通过；focused 8/8 通过；fresh 打包成功；`pack:verify` 验证 72 个运行时包；打包启动冒烟和 CI 同款 Directory Picker E2E 均通过。完整 `pnpm verify` 已在 Node 24.19.0 环境启动并继续执行，PR CI 将对合并候选再次完整验证。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A：这是发布包运行时依赖完整性修复；验证由 fresh packaged Directory Picker E2E 覆盖。