### PR TITLE
fix(ci): skip gallery deploy without credentials

### DIFF
--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -11,6 +11,7 @@ name: Deploy Gallery
 # 需要的仓库 secrets：
 #   CLOUDFLARE_API_TOKEN   — 作用域：Account > Cloudflare Pages > Edit
 #   CLOUDFLARE_ACCOUNT_ID  — Cloudflare 账号 ID
+# 未配置完整凭据时仍执行产物一致性检查，但跳过外部部署。
 
 on:
   push:
@@ -56,10 +57,26 @@ jobs:
       - name: Gallery consistency
         run: pnpm gallery:check
 
+      - name: Detect Cloudflare deployment credentials
+        id: cloudflare
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Cloudflare credentials are not configured; gallery consistency passed and external deployment was skipped."
+          fi
+
       - name: Install wrangler
+        if: steps.cloudflare.outputs.configured == 'true'
         run: npm install -g wrangler@4
 
       - name: Deploy gallery
+        if: steps.cloudflare.outputs.configured == 'true'
         run: node scripts/deploy-gallery --project-name dsh-market-gallery
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/deploy-gallery-workflow.test.mjs
+++ b/scripts/deploy-gallery-workflow.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import test from 'node:test'
+import { parse } from 'yaml'
+
+test('gallery workflow always checks committed output and deploys only with complete Cloudflare credentials', async () => {
+  const workflow = parse(await readFile(
+    join(import.meta.dirname, '..', '.github', 'workflows', 'deploy-gallery.yml'),
+    'utf8',
+  ))
+  const steps = workflow.jobs.deploy.steps
+  const consistency = steps.find((step) => step.name === 'Gallery consistency')
+  const credentials = steps.find((step) => step.name === 'Detect Cloudflare deployment credentials')
+  const install = steps.find((step) => step.name === 'Install wrangler')
+  const deploy = steps.find((step) => step.name === 'Deploy gallery')
+
+  assert.equal(consistency.run, 'pnpm gallery:check')
+  assert.equal(consistency.if, undefined)
+  assert.equal(credentials.id, 'cloudflare')
+  assert.equal(credentials.env.CLOUDFLARE_API_TOKEN, '${{ secrets.CLOUDFLARE_API_TOKEN }}')
+  assert.equal(credentials.env.CLOUDFLARE_ACCOUNT_ID, '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}')
+  assert.match(credentials.run, /configured=true/u)
+  assert.match(credentials.run, /configured=false/u)
+  assert.match(credentials.run, /::notice::/u)
+  assert.equal(install.if, "steps.cloudflare.outputs.configured == 'true'")
+  assert.equal(deploy.if, "steps.cloudflare.outputs.configured == 'true'")
+})

--- a/scripts/deploy-gallery-workflow.test.mjs
+++ b/scripts/deploy-gallery-workflow.test.mjs
@@ -2,27 +2,36 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import test from 'node:test'
-import { parse } from 'yaml'
+
+function stepBlock(workflow, name) {
+  const normalized = workflow.replace(/\r\n?/gu, '\n')
+  const escapedName = name.replace(/[.*+?^$\{\}()|[\]\\]/gu, '\\$&')
+  const match = new RegExp(
+    `      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - name:|$)`,
+    'u',
+  ).exec(normalized)
+  assert.ok(match, `workflow is missing step: ${name}`)
+  return match[0]
+}
 
 test('gallery workflow always checks committed output and deploys only with complete Cloudflare credentials', async () => {
-  const workflow = parse(await readFile(
+  const workflow = await readFile(
     join(import.meta.dirname, '..', '.github', 'workflows', 'deploy-gallery.yml'),
     'utf8',
-  ))
-  const steps = workflow.jobs.deploy.steps
-  const consistency = steps.find((step) => step.name === 'Gallery consistency')
-  const credentials = steps.find((step) => step.name === 'Detect Cloudflare deployment credentials')
-  const install = steps.find((step) => step.name === 'Install wrangler')
-  const deploy = steps.find((step) => step.name === 'Deploy gallery')
+  )
+  const consistency = stepBlock(workflow, 'Gallery consistency')
+  const credentials = stepBlock(workflow, 'Detect Cloudflare deployment credentials')
+  const install = stepBlock(workflow, 'Install wrangler')
+  const deploy = stepBlock(workflow, 'Deploy gallery')
 
-  assert.equal(consistency.run, 'pnpm gallery:check')
-  assert.equal(consistency.if, undefined)
-  assert.equal(credentials.id, 'cloudflare')
-  assert.equal(credentials.env.CLOUDFLARE_API_TOKEN, '${{ secrets.CLOUDFLARE_API_TOKEN }}')
-  assert.equal(credentials.env.CLOUDFLARE_ACCOUNT_ID, '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}')
-  assert.match(credentials.run, /configured=true/u)
-  assert.match(credentials.run, /configured=false/u)
-  assert.match(credentials.run, /::notice::/u)
-  assert.equal(install.if, "steps.cloudflare.outputs.configured == 'true'")
-  assert.equal(deploy.if, "steps.cloudflare.outputs.configured == 'true'")
+  assert.match(consistency, /run: pnpm gallery:check/u)
+  assert.doesNotMatch(consistency, /^\s*if:/mu)
+  assert.match(credentials, /^\s*id: cloudflare$/mu)
+  assert.match(credentials, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/u)
+  assert.match(credentials, /CLOUDFLARE_ACCOUNT_ID: \$\{\{ secrets\.CLOUDFLARE_ACCOUNT_ID \}\}/u)
+  assert.match(credentials, /configured=true/u)
+  assert.match(credentials, /configured=false/u)
+  assert.match(credentials, /::notice::/u)
+  assert.match(install, /if: steps\.cloudflare\.outputs\.configured == 'true'/u)
+  assert.match(deploy, /if: steps\.cloudflare\.outputs\.configured == 'true'/u)
 })


### PR DESCRIPTION
## 摘要（Summary）

修复 Gallery 部署在未配置可选 Cloudflare 凭据时长期无条件失败的问题。画廊产物一致性仍始终强制检查；只有 API Token 与 Account ID 同时存在时才安装 wrangler 并执行外部部署，否则输出明确 notice 后成功跳过。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（Gallery GitHub Actions 工作流与脚本回归测试）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

`git fetch desktop main && git merge --no-edit desktop/main`

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：OpenAI GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

维持仓库现有版权声明。

## 社区插件索引登记（Community Plugin Index）

N/A。

## 本地验证（Local Validation）

执行的命令：

```text
node --test scripts/deploy-gallery-workflow.test.mjs
pnpm test:scripts
pnpm gallery:check
YAML parse check

git diff --check
```

结果摘要：

定向回归 1/1、完整脚本 150/150、Gallery 一致性、YAML 解析与 diff 检查全部通过。历史失败日志已确认缺少的两项凭据均为空，Gallery 构建与一致性步骤此前已成功。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A，本次仅修复 CI 外部部署条件，不改变应用界面。