### PR TITLE
fix(release): prepare desktop 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 English: No changes yet.
 
-## 3.0.0 - 2026-08-22
+## 3.0.1 - 2026-08-22
 
 中文：
 
@@ -19,6 +19,7 @@ English: No changes yet.
 - 扩展坞加入原生社区插件市场，直接读取 `awesome-dsh-plugin.com/plugins.json` 索引并提供本地搜索、分类、排序和分页，不再嵌入第三方市场页面或显示其沙箱边界栏。安装只把不透明目录 ID 交给主进程解析，经一次原生确认后复用完整权限的事务安装、Runtime 重启和失败回滚；旧 `dshmarket` 运行时依赖已退役。
 - 新增独立嵌入式终端、受校验的 Managed Git 修复路径，以及不依赖主 Runtime 的恢复界面和隔离恢复会话；迁移完成标记缺失时可从已提交 journal 自愈，存在中断 journal 时仍严格保留恢复流程。
 - 修复 Task Ledger v3 过长错误文本导致后续写入永久失败、损坏 v3 被过期 v2 静默覆盖、SSH 断线重试失效、连接替换泄漏并拆错隧道、取消请求误报成功和分块上传绕过大小限制等稳定性问题，并补齐回归测试。
+- 修复 Windows 发布 Runner 上内置终端工作目录门禁依赖 xterm 可视区长路径文本而重复超时的问题；PowerShell 现在内部比较完整规范化路径并输出有界结果标记，仍严格验证真实 Shell cwd，同时提供明确的 mismatch 诊断。
 
 English:
 
@@ -31,6 +32,7 @@ English:
 - Extension Dock now includes a native community plugin market backed directly by the `awesome-dsh-plugin.com/plugins.json` index, with local search, category filtering, sorting, and pagination. It no longer embeds the third-party market page or its sandbox boundary banner. Installation passes only an opaque catalog ID to the main process, then reuses the full-permission transactional installer, Runtime restart, and rollback after one native confirmation; the old `dshmarket` runtime dependency is retired.
 - Added a standalone embedded terminal, a validated Managed Git repair path, and recovery surfaces and isolated recovery sessions that do not depend on the primary Runtime. A missing migration completion marker can self-heal from a committed journal, while an interrupted journal still preserves the strict recovery path.
 - Fixed Task Ledger v3 write poisoning from oversized error text, stale v2 data replacing a damaged v3 ledger, ineffective SSH disconnect retries, connection replacement leaks and wrong-tunnel teardown, cancellation falsely reporting success, and chunked uploads bypassing the size limit, with regression coverage for each class.
+- Fixed repeated Windows release-runner timeouts caused by matching a long terminal working-directory path in the visible xterm viewport. PowerShell now compares the full normalized path internally and emits a bounded result marker, preserving strict validation of the real shell cwd while reporting an explicit mismatch.
 
 ## 2.7.0 - 2026-08-20
 
@@ -66,7 +68,7 @@ English:
 - Git Graph Host 增加受控 Worktree 服务和 ID-only loopback 路由，限制 realpath、分支、冲突、操作中状态和丢弃确认；取消只取消 Session，不自动清理 Worktree。
 - Runtime Provider 缺少 `workspace.register`、`session.create` 或 `session.observe` 时记录能力证据并显式回退现有 shared-workspace；Session CWD 不匹配时阻断。
 - 增加有界 Evidence 面板、Commit/Merge/Keep/二次确认 Discard 审核、运行通知 Deep Link，以及真实临时 Git 仓库 Candidate 执行兼容夹具。
-- 历史 2.6 正式版曾默认启用仅用于产品改进的有界匿名统计；该默认值已由 3.0.0 的“默认关闭、仅用户主动诊断导出”政策取代。
+- 历史 2.6 正式版曾默认启用仅用于产品改进的有界匿名统计；该默认值已由 3.0.1 的“默认关闭、仅用户主动诊断导出”政策取代。
 
 English:
 
@@ -74,7 +76,7 @@ English:
 - Git Graph Host adds a controlled Worktree service and ID-only loopback routes with realpath, branch, conflict, in-progress, and discard-confirmation fences. Cancellation cancels only the Session and never removes a Worktree implicitly.
 - When `workspace.register`, `session.create`, or `session.observe` is unavailable, the Runtime Provider records capability evidence and falls back explicitly to the existing shared-workspace executor; a Session CWD mismatch is blocked.
 - Added a bounded Evidence panel, Commit/Merge/Keep/two-step Discard review, run deep-link notifications, and a real temporary Git repository Candidate execution fixture.
-- Historical 2.6 release builds enabled bounded anonymous product metrics by default. That default is superseded in 3.0.0 by the off-by-default, user-initiated diagnostic-export policy.
+- Historical 2.6 release builds enabled bounded anonymous product metrics by default. That default is superseded in 3.0.1 by the off-by-default, user-initiated diagnostic-export policy.
 
 ## 2.5.0 - 2026-08-19
 

--- a/README.en.md
+++ b/README.en.md
@@ -20,13 +20,13 @@ DeepSeek Harness Desktop brings the complete DSH Web surface to a Windows EXE. I
 
 If this project helps you, Star the [GitHub repository](https://github.com/ningbainb/deepseek-harness-desktop) so more desktop users can discover it.
 
-### Latest release: 3.0.0
+### Latest release: 3.0.1
 
-`desktop-v3.0.0` is the platform Stable release: [read the full release notes](docs/launch/release-notes.md) · [read the compatibility and runtime policies](docs/compatibility-policy.md) · [read upgrade, rollback, and known limitations](docs/upgrade-and-rollback.md). Release assets include `SHA256SUMS.txt`, `release-manifest.json`, and channel metadata; the manifest records the actual signature state of each asset.
+`desktop-v3.0.1` is the platform Stable release: [read the full release notes](docs/launch/release-notes.md) · [read the compatibility and runtime policies](docs/compatibility-policy.md) · [read upgrade, rollback, and known limitations](docs/upgrade-and-rollback.md). Release assets include `SHA256SUMS.txt`, `release-manifest.json`, and channel metadata; the manifest records the actual signature state of each asset.
 
 | Version | Highlights |
 | --- | --- |
-| **3.0.0** | Freezes SDK/Contract/Provider/Schema boundaries; separates Stable and Beta; adds the controlled Runtime matrix and patch policy, migration/rollback assistant, privacy-redacted JSON/ZIP diagnostics, and release-manifest/signing infrastructure; telemetry is disabled by default. |
+| **3.0.1** | Freezes SDK/Contract/Provider/Schema boundaries; separates Stable and Beta; adds the controlled Runtime matrix and patch policy, migration/rollback assistant, privacy-redacted JSON/ZIP diagnostics, and release-manifest/signing infrastructure; telemetry is disabled by default. |
 | **2.7.0** | Fixes the Windows 8% Runtime startup failure and moves to DSH rc.7; adds tray background automation, Host durable task scheduling, plugin compatibility declarations/lock state, the browser-safe Desktop SDK, safe workspace external opening, and Candidate Matrix. |
 | **2.6.0** | Adds Task Board v3 Projects, Task Runs, derived Evidence, explicit Git Worktree review, capability-based shared-workspace fallback, and Candidate execution fixtures. Its historical anonymous-metrics behavior is replaced by the 3.0 default-off policy. |
 | **2.5.0** | Adds the Runtime Adapter and upstream compatibility defenses, secure `.dshpreset` and Web Profile migration, atomic plugin batches, strict deep-link/file ingress, and structured notifications. |
@@ -43,7 +43,7 @@ If this project helps you, Star the [GitHub repository](https://github.com/ningb
 | **0.1.4** | Moves the pet to the global Shell Overlay so it appears on home and settings screens, restores all five Web UI plugin settings cards, and lists all nine packaged skins in Skin Center. |
 | **0.1.3** | Adds stable GitHub Release checks, bilingual update notes, user-confirmed downloads, taskbar progress, and a second confirmation before installation. |
 
-### 3.0.0 Platform-Stability Highlights
+### 3.0.1 Platform-Stability Highlights
 
 - **Stable public boundaries**: Desktop Contract and SDK remain on 1.x. Runtime Provider, Preset, Task/Run/Evidence, Deep Link, Runtime matrix, and patch registry have machine-readable schemas, version rules, and compatibility fixtures. Plugins enhance through capability detection while remaining usable in ordinary DSH Web.
 - **Stable Runtime is deliberate**: Stable accepts only exact `known-good` or `supported` matrix entries after provider, Desktop range, package integrity, lockfile, and patch evidence agree. Candidate and blocked Runtime entries cannot be silently selected.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ DeepSeek Harness Desktop 将原版 DSH Web 界面完整装进 Windows EXE：不�
 
 如果这个项目对你有帮助，欢迎在 [GitHub 仓库](https://github.com/ningbainb/deepseek-harness-desktop) 点 Star，帮助更多桌面版用户发现它。
 
-### 最新版：3.0.0
+### 最新版：3.0.1
 
-`desktop-v3.0.0` 是平台稳定版：[查看完整发布说明](docs/launch/release-notes.md) · [查看兼容性和运行时政策](docs/compatibility-policy.md) · [查看升级、回滚和已知限制](docs/upgrade-and-rollback.md)。发布资产包含 `SHA256SUMS.txt`、`release-manifest.json` 与频道元数据；签名状态以同一 Release 的 manifest 为准。
+`desktop-v3.0.1` 是平台稳定版：[查看完整发布说明](docs/launch/release-notes.md) · [查看兼容性和运行时政策](docs/compatibility-policy.md) · [查看升级、回滚和已知限制](docs/upgrade-and-rollback.md)。发布资产包含 `SHA256SUMS.txt`、`release-manifest.json` 与频道元数据；签名状态以同一 Release 的 manifest 为准。
 
 | 版本 | 主要更新 |
 | --- | --- |
-| **3.0.0** | 冻结 SDK/Contract/Provider/Schema，Stable/Beta 分离，受控 Runtime matrix 与 patch 政策，独立升级/回滚助手，隐私脱敏 JSON/ZIP 诊断包，签名与 release manifest 发布基础设施；遥测默认关闭。 |
+| **3.0.1** | 冻结 SDK/Contract/Provider/Schema，Stable/Beta 分离，受控 Runtime matrix 与 patch 政策，独立升级/回滚助手，隐私脱敏 JSON/ZIP 诊断包，签名与 release manifest 发布基础设施；遥测默认关闭。 |
 | **2.7.0** | 修复 Windows 8% Runtime 启动故障并升级到 DSH rc.7；新增托盘后台自动化、Host 持久任务调度、插件兼容声明/锁、browser-safe Desktop SDK、安全工作区外部打开和 Candidate Matrix。 |
 | **2.6.0** | Task Board v3 引入 Project、Task Run、Evidence 与 Git Worktree 审核流；Runtime Provider 缺少可选能力时显式回退 shared-workspace，并加入 Candidate 执行兼容夹具。该版本的匿名统计行为仅作历史记录，已由 3.0 的默认关闭政策取代。 |
 | **2.5.0** | 新增 Runtime Adapter 与上游兼容防线、安全 `.dshpreset` 和 Web Profile 迁移、原子插件批量事务、严格 Deep Link/文件关联与结构化通知。 |
@@ -43,7 +43,7 @@ DeepSeek Harness Desktop 将原版 DSH Web 界面完整装进 Windows EXE：不�
 | **0.1.4** | 桌宠迁移到全局 Shell Overlay，首页和设置页均可见；恢复五张 Web UI 插件配置卡；皮肤中心完整展示安装版随附的九套皮肤。 |
 | **0.1.3** | 加入稳定版 GitHub Release 更新检查、双语更新说明、用户确认下载、任务栏进度和二次确认安装。 |
 
-### 3.0.0 平台稳定版亮点
+### 3.0.1 平台稳定版亮点
 
 - **可依赖的公开边界**：Desktop Contract 与 SDK 保持 1.x；Runtime Provider、Preset、Task/Run/Evidence、Deep Link、runtime matrix 和 patch registry 有机器 Schema、版本政策与兼容夹具。插件按 capability detection 增强，在普通 DSH Web 中保持可用。
 - **Stable Runtime 不是猜测**：Stable 只接受精确 `known-good` / `supported` 矩阵项，并核对 provider、Desktop 范围、包完整性、lockfile 和 patch 证据；候选或 blocked Runtime 不会被悄悄放行。

--- a/apps/dsh-desktop/package.json
+++ b/apps/dsh-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-ai/dsh-desktop",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "Lossless desktop shell for DeepSeek Harness and the complete dsh-web-ui plugin collection",
   "author": "DeepSeek Harness Desktop contributors",

--- a/apps/dsh-desktop/runtime-support/community-plugin-quality.json
+++ b/apps/dsh-desktop/runtime-support/community-plugin-quality.json
@@ -7,7 +7,7 @@
     "normalStartupNetwork": false
   },
   "verifiedAt": "2026-08-20",
-  "desktopVersion": "3.0.0",
+  "desktopVersion": "3.0.1",
   "upstreamVersion": "0.1.1-rc.1",
   "entries": [
     {
@@ -48,7 +48,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-aionui-panel build",
@@ -92,7 +92,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-git-graph build",
@@ -136,7 +136,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-mode-switcher build",
@@ -180,7 +180,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-blue-fantasy build",
@@ -223,7 +223,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-center build",
@@ -266,7 +266,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-dragon-heir build",
@@ -309,7 +309,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-harbor build",
@@ -352,7 +352,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-miku build",
@@ -395,7 +395,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-minecraft build",
@@ -438,7 +438,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-qq2006 build",
@@ -481,7 +481,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-qq98 build",
@@ -524,7 +524,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-ths build",
@@ -567,7 +567,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-trading build",
@@ -610,7 +610,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-whale-song build",
@@ -653,7 +653,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-skin-xp build",
@@ -714,7 +714,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-task-board build",
@@ -758,7 +758,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-client-ui-web-ui-settings build",
@@ -802,7 +802,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-desktop-compat build",
@@ -846,7 +846,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-liangshen build",
@@ -890,7 +890,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-live-stats build",
@@ -934,7 +934,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-particle-theme build",
@@ -978,7 +978,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-pet build",
@@ -1022,7 +1022,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-remote-web-ui build",
@@ -1066,7 +1066,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-skins build"
@@ -1108,7 +1108,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-ssh build",
@@ -1152,7 +1152,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-tool-describe-image build",
@@ -1196,7 +1196,7 @@
         "status": "not-recorded"
       },
       "testCombination": {
-        "desktopVersion": "3.0.0",
+        "desktopVersion": "3.0.1",
         "upstreamVersion": "0.1.1-rc.1",
         "commands": [
           "pnpm --filter @linxin666/dsh-web-ui-all build"

--- a/apps/dsh-desktop/runtime-support/known-good.json
+++ b/apps/dsh-desktop/runtime-support/known-good.json
@@ -10,8 +10,8 @@
     "clientSlotScan": "scripts/audit-dsh-coupling.mjs"
   },
   "desktop": {
-    "version": "3.0.0",
-    "rootVersion": "3.0.0",
+    "version": "3.0.1",
+    "rootVersion": "3.0.1",
     "nodeEngine": "^22.19.0 || >=24.0.0",
     "packageManager": "pnpm@11.22.0"
   },

--- a/apps/dsh-desktop/runtime-support/supported-runtimes.json
+++ b/apps/dsh-desktop/runtime-support/supported-runtimes.json
@@ -12,7 +12,7 @@
       "status": "known-good",
       "upstreamVersion": "0.1.1-rc.1",
       "providerId": "dsh-cli-provider-v1",
-      "desktopRange": "=3.0.0",
+      "desktopRange": "=3.0.1",
       "capabilities": [
         {
           "id": "host-service.register",

--- a/apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs
+++ b/apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs
@@ -22,6 +22,9 @@ function requiredText(value, label) {
   return value
 }
 
+const desktopManifest = JSON.parse(await readFile(resolve(SCRIPT_DIRECTORY, '..', 'package.json'), 'utf8'))
+export const MIGRATION_MATRIX_DESKTOP_VERSION = requiredText(desktopManifest.version, 'Desktop package version')
+
 function fixtureVersion(value) {
   if (!MIGRATION_MATRIX_FIXTURE_VERSIONS.includes(value)) throw new TypeError('migration fixture version is unsupported')
   return value
@@ -229,7 +232,7 @@ async function verifyCommittedMigration(layout) {
   } catch (error) {
     throw new Error(`migrated Runtime support state is invalid: ${error instanceof Error ? error.message : String(error)}`)
   }
-  if (!isRecord(runtimeSupport) || runtimeSupport.desktopVersion !== '3.0.0' || !['known-good', 'supported'].includes(runtimeSupport.status)) {
+  if (!isRecord(runtimeSupport) || runtimeSupport.desktopVersion !== MIGRATION_MATRIX_DESKTOP_VERSION || !['known-good', 'supported'].includes(runtimeSupport.status)) {
     throw new Error(`migrated Runtime support state is not release-eligible for fixture ${layout.version}`)
   }
   let taskDocument

--- a/apps/dsh-desktop/scripts/terminal-e2e-probe.mjs
+++ b/apps/dsh-desktop/scripts/terminal-e2e-probe.mjs
@@ -1,0 +1,22 @@
+import { win32 } from 'node:path'
+
+export const CWD_PROBE_SUCCESS = '__DSH_CWD_OK__'
+export const CWD_PROBE_MISMATCH = '__DSH_CWD_MISMATCH__'
+
+export function createPowerShellCwdProbe(expectedPath) {
+  if (
+    typeof expectedPath !== 'string'
+    || expectedPath.length === 0
+    || expectedPath.length > 4_096
+    || expectedPath.includes('\0')
+    || !win32.isAbsolute(expectedPath)
+  ) {
+    throw new TypeError('expected terminal cwd must be an absolute path')
+  }
+  const encoded = Buffer.from(expectedPath, 'utf8').toString('base64')
+  return [
+    `$expected=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encoded}'))`,
+    '$actual=[IO.Path]::GetFullPath($PWD.Path)',
+    "if($actual -ieq [IO.Path]::GetFullPath($expected)){Write-Output ('__DSH_'+'CWD_OK__')}else{Write-Output ('__DSH_'+'CWD_MISMATCH__'+$actual)}",
+  ].join(';')
+}

--- a/apps/dsh-desktop/scripts/verify-terminal.mjs
+++ b/apps/dsh-desktop/scripts/verify-terminal.mjs
@@ -10,6 +10,11 @@ import electronPath from 'electron'
 import { _electron as electron } from 'playwright'
 
 import { seedPrimaryRuntimePermissionForTest } from './primary-runtime-permission-fixture.mjs'
+import {
+  CWD_PROBE_MISMATCH,
+  CWD_PROBE_SUCCESS,
+  createPowerShellCwdProbe,
+} from './terminal-e2e-probe.mjs'
 
 const appDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const packagedExecutable = process.env.DSH_DESKTOP_E2E_EXECUTABLE
@@ -162,14 +167,23 @@ try {
     return output.toLowerCase().includes(`__dsh_pnpm__${expected}`.toLowerCase())
   }, expectedPnpmShim, { timeout: 15_000 })
   const expectedProfileCwd = resolve(dshHome, 'profiles', 'desktop')
-  await terminal.keyboard.type('Write-Output ("__DSH_CWD__" + $PWD.Path)')
+  await terminal.keyboard.type(createPowerShellCwdProbe(expectedProfileCwd))
   await terminal.keyboard.press('Enter')
-  await terminal.waitForFunction((expected) => {
+  await terminal.waitForFunction(({ success, mismatch }) => {
     const output = document.querySelector('.xterm-rows')?.textContent ?? ''
-    return output.toLowerCase().includes(`__dsh_cwd__${expected}`.toLowerCase())
-  }, expectedProfileCwd, { timeout: 15_000 })
+    return output.includes(success) || output.includes(mismatch)
+  }, { success: CWD_PROBE_SUCCESS, mismatch: CWD_PROBE_MISMATCH }, { timeout: 15_000 })
+  const terminalOutput = await terminal.locator('.xterm-rows').textContent() ?? ''
+  assert.ok(
+    terminalOutput.includes(CWD_PROBE_SUCCESS),
+    `terminal shell cwd does not match the Desktop Profile: ${terminalOutput.slice(-2_000)}`,
+  )
   const context = await terminal.locator('#terminal-context').textContent()
   assert.match(context ?? '', /PowerShell/u)
+  assert.ok(
+    (context ?? '').toLowerCase().includes(expectedProfileCwd.toLowerCase()),
+    `terminal context does not identify the Desktop Profile cwd: ${context}`,
+  )
   await Promise.all([
     terminal.waitForEvent('close'),
     terminal.getByRole('button', { name: '收起内置终端', exact: true }).click(),

--- a/apps/dsh-desktop/test/packaged-migration-matrix.test.mjs
+++ b/apps/dsh-desktop/test/packaged-migration-matrix.test.mjs
@@ -10,6 +10,7 @@ import { promisify } from 'node:util'
 import {
   MIGRATION_MATRIX_FIXTURE_ROOT,
   MIGRATION_MATRIX_FIXTURE_VERSIONS,
+  MIGRATION_MATRIX_DESKTOP_VERSION,
   materializePackagedMigrationFixture,
   packagedMigrationFixtureMode,
   runPackagedMigrationMatrix,
@@ -18,10 +19,17 @@ import {
 const execFileAsync = promisify(execFile)
 const migrationMatrixScript = fileURLToPath(new URL('../scripts/verify-packaged-migration-matrix.mjs', import.meta.url))
 const migrationMatrixRunner = fileURLToPath(new URL('../scripts/packaged-migration-matrix-runner.mjs', import.meta.url))
+const desktopManifest = fileURLToPath(new URL('../package.json', import.meta.url))
 
 async function expectMissing(path) {
   await assert.rejects(access(path), (error) => error?.code === 'ENOENT')
 }
+
+test('packaged migration eligibility follows the current Desktop patch version', async () => {
+  const manifest = JSON.parse(await readFile(desktopManifest, 'utf8'))
+  assert.equal(MIGRATION_MATRIX_DESKTOP_VERSION, manifest.version)
+  assert.equal(manifest.version, '3.0.1')
+})
 
 test('packaged migration fixture materialization copies only Desktop-owned state and maps every supported ledger generation', async () => {
   for (const version of MIGRATION_MATRIX_FIXTURE_VERSIONS) {

--- a/apps/dsh-desktop/test/terminal-e2e-probe.test.mjs
+++ b/apps/dsh-desktop/test/terminal-e2e-probe.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CWD_PROBE_MISMATCH,
+  CWD_PROBE_SUCCESS,
+  createPowerShellCwdProbe,
+} from '../scripts/terminal-e2e-probe.mjs'
+
+test('PowerShell cwd probe compares the full path but emits bounded result markers', () => {
+  const expected = String.raw`C:\Users\runner admin\AppData\Local\Temp\dsh-terminal-e2e-long-path\dsh-home\profiles\desktop`
+  const command = createPowerShellCwdProbe(expected)
+
+  assert.match(command, /FromBase64String/u)
+  assert.equal(command.includes(expected), false, 'the long path must not be echoed into the xterm viewport')
+  assert.equal(command.includes(CWD_PROBE_SUCCESS), false, 'the echoed command must not contain the complete success marker')
+  assert.equal(command.includes(CWD_PROBE_MISMATCH), false, 'the echoed command must not contain the complete mismatch marker')
+
+  const encoded = command.match(/FromBase64String\('(?<encoded>[A-Za-z0-9+/=]+)'\)/u)?.groups?.encoded
+  assert.equal(Buffer.from(encoded, 'base64').toString('utf8'), expected)
+})
+
+test('PowerShell cwd probe rejects invalid expected paths', () => {
+  for (const value of ['', 'relative\\path', 'C:\\broken\0path']) {
+    assert.throws(() => createPowerShellCwdProbe(value), /absolute path/u)
+  }
+})

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.json
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "desktopVersion": "3.0.0",
+  "desktopVersion": "3.0.1",
   "upstreamVersion": "0.1.1-rc.1",
   "lockfileSha256": "5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a",
   "policy": {
@@ -2692,31 +2692,25 @@
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
-      "line": 115,
+      "line": 118,
       "operation": "profileDir"
     },
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
-      "line": 116,
+      "line": 119,
       "operation": "profileDir"
     },
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
-      "line": 120,
+      "line": 123,
       "operation": "profileDir"
     },
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
-      "line": 143,
-      "operation": "profileDir"
-    },
-    {
-      "category": "profile-home",
-      "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
-      "line": 154,
+      "line": 146,
       "operation": "profileDir"
     },
     {
@@ -2728,7 +2722,13 @@
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
-      "line": 193,
+      "line": 160,
+      "operation": "profileDir"
+    },
+    {
+      "category": "profile-home",
+      "path": "apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs",
+      "line": 196,
       "operation": "profileDir"
     },
     {
@@ -2914,7 +2914,7 @@
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/scripts/verify-terminal.mjs",
-      "line": 100,
+      "line": 105,
       "operation": "DSH_HOME"
     },
     {
@@ -4594,13 +4594,13 @@
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/test/packaged-migration-matrix.test.mjs",
-      "line": 35,
+      "line": 43,
       "operation": "profileDir"
     },
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/test/packaged-migration-matrix.test.mjs",
-      "line": 44,
+      "line": 52,
       "operation": "profileDir"
     },
     {

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.md
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.md
@@ -1,6 +1,6 @@
 # Desktop 2.5 DSH coupling audit
 
-Authoritative Desktop version: 3.0.0.
+Authoritative Desktop version: 3.0.1.
 
 Stable DSH package version: 0.1.1-rc.1.
 
@@ -334,13 +334,13 @@ Capability discovery is compatibility evidence only. Renderer surface identity, 
 | profile-home | apps/dsh-desktop/scripts/measure-profile.mjs | 44 | ensureDesktopProfile |
 | profile-home | apps/dsh-desktop/scripts/measure-profile.mjs | 50 | resolveRuntimePackages |
 | profile-home | apps/dsh-desktop/scripts/measure-startup-fps.mjs | 23 | DSH_HOME |
-| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 115 | profileDir |
-| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 116 | profileDir |
-| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 120 | profileDir |
-| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 143 | profileDir |
-| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 154 | profileDir |
+| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 118 | profileDir |
+| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 119 | profileDir |
+| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 123 | profileDir |
+| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 146 | profileDir |
 | profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 157 | profileDir |
-| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 193 | profileDir |
+| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 160 | profileDir |
+| profile-home | apps/dsh-desktop/scripts/packaged-migration-matrix-runner.mjs | 196 | profileDir |
 | profile-home | apps/dsh-desktop/scripts/packaged-smoke-runner.mjs | 57 | DSH_HOME |
 | profile-home | apps/dsh-desktop/scripts/preset-deep-link-runner.mjs | 63 | DSH_HOME |
 | profile-home | apps/dsh-desktop/scripts/verify-conversation-skills.mjs | 27 | DSH_HOME |
@@ -371,7 +371,7 @@ Capability discovery is compatibility evidence only. Renderer surface identity, 
 | profile-home | apps/dsh-desktop/scripts/verify-runtime-provider.mjs | 43 | profileDir |
 | profile-home | apps/dsh-desktop/scripts/verify-settings-window.mjs | 57 | DSH_HOME |
 | profile-home | apps/dsh-desktop/scripts/verify-star-prompt.mjs | 25 | DSH_HOME |
-| profile-home | apps/dsh-desktop/scripts/verify-terminal.mjs | 100 | DSH_HOME |
+| profile-home | apps/dsh-desktop/scripts/verify-terminal.mjs | 105 | DSH_HOME |
 | profile-home | apps/dsh-desktop/scripts/verify-update-shutdown.mjs | 71 | DSH_HOME |
 | profile-home | apps/dsh-desktop/scripts/verify-update-shutdown.mjs | 134 | DSH_HOME |
 | profile-home | apps/dsh-desktop/scripts/verify-window-chrome.mjs | 43 | DSH_HOME |
@@ -651,8 +651,8 @@ Capability discovery is compatibility evidence only. Renderer surface identity, 
 | profile-home | apps/dsh-desktop/test/migration-runtime-matrix.test.mjs | 290 | profileDir |
 | profile-home | apps/dsh-desktop/test/migration-runtime-matrix.test.mjs | 290 | profileDir |
 | profile-home | apps/dsh-desktop/test/migration-runtime-matrix.test.mjs | 291 | profileDir |
-| profile-home | apps/dsh-desktop/test/packaged-migration-matrix.test.mjs | 35 | profileDir |
-| profile-home | apps/dsh-desktop/test/packaged-migration-matrix.test.mjs | 44 | profileDir |
+| profile-home | apps/dsh-desktop/test/packaged-migration-matrix.test.mjs | 43 | profileDir |
+| profile-home | apps/dsh-desktop/test/packaged-migration-matrix.test.mjs | 52 | profileDir |
 | profile-home | apps/dsh-desktop/test/plugin-recovery.test.mjs | 19 | ensureDesktopProfile |
 | profile-home | apps/dsh-desktop/test/plugin-recovery.test.mjs | 124 | profileDir |
 | profile-home | apps/dsh-desktop/test/plugin-recovery.test.mjs | 131 | profileDir |

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -8,7 +8,7 @@ The DSH home remains `DSH_HOME` or `~/.dsh`. The desktop app runs the managed `~
 
 ## Desktop 3.0 platform policy
 
-Desktop 3.0.0 is the platform-stability release. The 2.x behavior documented below remains the compatibility foundation; new public integrations must use the 3.0 contracts and policies rather than infer behavior from the internal Electron implementation.
+Desktop 3.0.1 is the platform-stability release. The 2.x behavior documented below remains the compatibility foundation; new public integrations must use the 3.0 contracts and policies rather than infer behavior from the internal Electron implementation.
 
 The Desktop Client SDK and Desktop Contract remain 1.x. Runtime Provider, Preset, Project/Task/Run/Evidence, Deep Link, plugin compatibility, Runtime matrix, and compat-patch inputs have machine-readable definitions. The applicable additive-change, deprecation, and major-version rules are in the [compatibility policy](compatibility-policy.md) and [schema versioning guide](schema-versioning.md).
 

--- a/docs/launch/desktop-release-workflow.md
+++ b/docs/launch/desktop-release-workflow.md
@@ -1,6 +1,6 @@
 # DeepSeek Harness Desktop 3.0 release preparation and handoff
 
-This is the current 3.0.0 maintainer preparation and handoff guide. It describes the repository contracts and verification evidence for a possible release; it does not authorize a commit, push, tag, GitHub Release change, deployment, or external announcement. A maintainer with explicit authority must make each external-state decision separately.
+This is the current 3.0.1 maintainer preparation and handoff guide. It describes the repository contracts and verification evidence for a possible release; it does not authorize a commit, push, tag, GitHub Release change, deployment, or external announcement. A maintainer with explicit authority must make each external-state decision separately.
 
 ## Sources of truth
 

--- a/docs/launch/release-notes.md
+++ b/docs/launch/release-notes.md
@@ -1,15 +1,16 @@
-# DeepSeek Harness Desktop 3.0.0
+# DeepSeek Harness Desktop 3.0.1
 
 ## 中文
 
 ### 本次亮点
 
-- 3.0.0 是平台稳定版。Desktop Client SDK、Desktop Contract 和 Runtime Provider 继续维持 1.x；Preset、Project/Task/Run/Evidence、Deep Link、插件兼容元数据、supported-runtime matrix 与 compat patch registry 都有可机器校验的定义、兼容夹具和同 major 的增量演进规则。
+- 3.0.1 是平台稳定版。Desktop Client SDK、Desktop Contract 和 Runtime Provider 继续维持 1.x；Preset、Project/Task/Run/Evidence、Deep Link、插件兼容元数据、supported-runtime matrix 与 compat patch registry 都有可机器校验的定义、兼容夹具和同 major 的增量演进规则。
 - Stable Runtime 不跟随 `latest`。只有状态为 `known-good` 或 `supported`，并且 provider、Desktop 范围、完整性、lockfile 与 patch 证据都匹配的矩阵项可以进入 Stable；`candidate` 只生成证据，`blocked` 不会被当成回退路径。
 - Migration Assistant 覆盖 2.3.0–2.7.0 升级矩阵并生成 `safe`、`needs-confirmation` 或 `blocked` 计划。识别出的 Task Store v2/v3 状态会被检测、校验并纳入白名单 snapshot/journal 边界；2.3 legacy browser-localStorage task state 必须先确认，扫描不会暴露其内容或 task/run 计数。确认后，受支持的保留同源 v1 数据只会通过 CSP、无调度、无权限的隐藏 probe 读取其键，且只会复制到空的 v3 Host ledger，再以 task count/fingerprint 验证，原浏览器值会保留。未知、缺失或已变化的 origin 会阻断复制并保留恢复/回滚指引。原子 journal 和有限期全局状态 snapshot 支持继续和回滚，且不复制项目文件或用户内容。
 - Desktop 默认不配置遥测端点，也不会自动上传诊断。用户确认后才会在自选位置导出经集中脱敏的 JSON/ZIP 诊断包，包内带清单和哈希；密钥、Token、Cookie、路径、完整 Prompt、完整 Session、Tool Result、项目内容和 SSH 私钥被排除。
 - 扩展坞新增原生社区插件市场，直接使用 `awesome-dsh-plugin.com/plugins.json` 作为索引并在本地完成搜索、分类、排序与分页，不嵌入第三方市场页面，也不再显示其沙箱边界栏。安装时 Renderer 只提交不透明目录 ID，主进程重新解析安装源，经一次原生确认后复用完整权限的事务安装、Runtime 重启与失败回滚；旧 `dshmarket` 运行时依赖已退役。
 - 新增独立嵌入式终端、受校验的 Managed Git 修复路径，以及不依赖主 Runtime 的恢复界面和隔离恢复会话。迁移完成标记缺失时可从已提交 journal 自愈，存在中断 journal 时仍保留严格的恢复流程。
+- Windows 发布门禁会让 PowerShell 在 Shell 内部比较完整规范化的 Desktop Profile 工作目录，并只向 xterm 输出有界结果标记；这避免 Runner 长路径换行或滚动造成误超时，同时保留对真实终端 cwd 的严格验证和 mismatch 诊断。
 - 修复 Task Ledger v3 写入被过长错误文本永久阻断、损坏 v3 被过期 v2 覆盖、SSH 断线重试失效、连接替换泄漏并拆错隧道、取消请求误报成功和分块上传绕过大小限制等问题，并加入对应回归测试。
 - 既有 Task Board、Scheduler、Worktree、Evidence、Preset、插件和完整 Harness Web Surface 继续工作；第三方应通过 capability detection 和公开 Schema 集成，而不是依赖私有实现细节。
 
@@ -26,7 +27,7 @@
 
 ### 下载与校验
 
-从同一 GitHub Release 下载 `DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe`、`SHA256SUMS.txt` 与 `release-manifest.json`。先用 `SHA256SUMS.txt` 比对安装包 SHA-256，再查看 manifest 中该资产的大小、哈希、频道、Runtime/Schema 信息和实际签名状态。安装器的 updater 哈希仍是基础完整性校验，签名是额外信任层；工作流会在正式 GitHub Release 正文末尾追加从已验证 manifest 得出的实际签名状态。
+从同一 GitHub Release 下载 `DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe`、`SHA256SUMS.txt` 与 `release-manifest.json`。先用 `SHA256SUMS.txt` 比对安装包 SHA-256，再查看 manifest 中该资产的大小、哈希、频道、Runtime/Schema 信息和实际签名状态。安装器的 updater 哈希仍是基础完整性校验，签名是额外信任层；工作流会在正式 GitHub Release 正文末尾追加从已验证 manifest 得出的实际签名状态。
 
 ### 说明
 
@@ -36,12 +37,13 @@
 
 ### Highlights
 
-- 3.0.0 is the platform-stability release. The Desktop Client SDK, Desktop Contract, and Runtime Provider stay on 1.x. Preset, Project/Task/Run/Evidence, Deep Link, plugin compatibility metadata, the supported-runtime matrix, and the compat-patch registry have machine-verifiable definitions, compatibility fixtures, and additive same-major evolution rules.
+- 3.0.1 is the platform-stability release. The Desktop Client SDK, Desktop Contract, and Runtime Provider stay on 1.x. Preset, Project/Task/Run/Evidence, Deep Link, plugin compatibility metadata, the supported-runtime matrix, and the compat-patch registry have machine-verifiable definitions, compatibility fixtures, and additive same-major evolution rules.
 - Stable Runtime does not follow `latest`. Only a `known-good` or `supported` matrix entry whose provider, Desktop range, integrity, lockfile, and patch evidence agree can enter Stable. A `candidate` produces evidence only, and a `blocked` entry is never a fallback.
 - Migration Assistant covers the 2.3.0 through 2.7.0 upgrade matrix and produces a `safe`, `needs-confirmation`, or `blocked` plan. Recognized Task Store v2/v3 state is detected, validated, and included in the allowlisted snapshot/journal boundary. The 2.3 legacy browser-localStorage task path deliberately requires confirmation, and the scan does not expose its contents or task/run counts. After confirmation, supported preserved-origin v1 data is read only through a hidden CSP/no-scheduler/no-permission probe, copied only into an empty v3 Host ledger, and verified by task count/fingerprint while preserving the original browser value. An unknown, missing, or changed origin blocks the copy and retains recovery/rollback guidance. Its atomic journal and bounded global-state snapshot support resume and rollback without copying project files or user content.
 - Desktop configures no telemetry endpoint by default and never uploads diagnostics automatically. After user confirmation, a centralized-redaction JSON/ZIP diagnostic bundle can be written to a chosen location with a manifest and hashes. Keys, tokens, cookies, paths, complete prompts, complete sessions, tool results, project content, and SSH private keys are excluded.
 - Extension Dock now includes a native community plugin market backed directly by the `awesome-dsh-plugin.com/plugins.json` index, with local search, category filtering, sorting, and pagination. It does not embed the third-party market page or show its sandbox boundary banner. The renderer submits only an opaque catalog ID; the main process resolves the install source again and reuses the full-permission transactional installer, Runtime restart, and rollback after one native confirmation. The old `dshmarket` runtime dependency is retired.
 - Added a standalone embedded terminal, a validated Managed Git repair path, and recovery surfaces and isolated recovery sessions that do not depend on the primary Runtime. A missing migration completion marker can self-heal from a committed journal, while an interrupted journal keeps the strict recovery path.
+- The Windows release gate now compares the full normalized Desktop Profile working directory inside PowerShell and emits only a bounded result marker to xterm. This avoids false Runner timeouts from long-path wrapping or scrolling while retaining strict validation of the real terminal cwd and explicit mismatch diagnostics.
 - Fixed Task Ledger v3 writes being permanently poisoned by oversized error text, stale v2 data replacing a damaged v3 ledger, ineffective SSH disconnect retries, connection replacement leaks and wrong-tunnel teardown, cancellation falsely reporting success, and chunked uploads bypassing the size limit, with regression coverage for each class.
 - Existing Task Board, Scheduler, Worktree, Evidence, Preset, plugin, and complete Harness Web Surface behavior remains available. Third parties should integrate through capability detection and public schemas instead of private implementation details.
 
@@ -58,7 +60,7 @@
 
 ### Download and verification
 
-Download `DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe`, `SHA256SUMS.txt`, and `release-manifest.json` from the same GitHub Release. Compare the installer SHA-256 with `SHA256SUMS.txt`, then inspect the manifest record for its size, hash, channel, Runtime/Schema information, and actual signature state. The updater hash remains the baseline integrity check; signing is an additional trust layer. The workflow appends the actual signing state derived from the verified manifest to the published GitHub Release body.
+Download `DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe`, `SHA256SUMS.txt`, and `release-manifest.json` from the same GitHub Release. Compare the installer SHA-256 with `SHA256SUMS.txt`, then inspect the manifest record for its size, hash, channel, Runtime/Schema information, and actual signature state. The updater hash remains the baseline integrity check; signing is an additional trust layer. The workflow appends the actual signing state derived from the verified manifest to the published GitHub Release body.
 
 ### Notice
 

--- a/docs/plans/2026-08-22-desktop-3.0.1-terminal-release-gate-design.md
+++ b/docs/plans/2026-08-22-desktop-3.0.1-terminal-release-gate-design.md
@@ -1,0 +1,17 @@
+# Desktop 3.0.1 terminal release-gate design
+
+## Problem
+
+The packaged-terminal release gate compared the complete PowerShell working-directory output with text in xterm's 24-row visible DOM. Two independent GitHub Windows runners timed out after the preceding terminal, Git, pnpm, and pnpm-shim checks passed. A long runner temporary path can wrap or leave the visible viewport, so this presentation-level lookup is not a reliable assertion of the shell state.
+
+## Design
+
+Keep the product behavior and the strict working-directory assertion unchanged. Encode the expected absolute Windows path as UTF-8 base64, reconstruct it inside PowerShell, normalize both expected and actual paths, and compare them case-insensitively in the shell. The command emits a short success or mismatch marker assembled from separate string fragments so PowerShell command echo cannot produce a false positive. The test waits for either marker, fails with bounded terminal output on mismatch, and independently checks that the terminal context identifies the expected Desktop Profile directory.
+
+## Alternatives
+
+Increasing the timeout would retain the viewport dependency and would not address two repeatable failures. Removing the assertion would weaken the release gate. Reading only the UI context would confirm the requested session metadata but not the actual PTY working directory. The shell-side comparison tests the real cwd while keeping the renderer observation bounded.
+
+## Verification
+
+A unit regression locks path validation, base64 transport, bounded markers, and protection from command-echo false positives. The existing Electron end-to-end test exercises a real PowerShell PTY. Repository verification, a fresh unsigned Windows package rehearsal, and the GitHub tag workflow must all pass before publication.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-web-ui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "DeepSeek Harness Web GUI 皮肤集合 + 主题库预览页（仿 Codex-Dream-Skin / DreamSkin.cc）。每个皮肤是符合官方标准（turtle-ui 式 setup）的独立可安装插件包。",
   "scripts": {

--- a/scripts/validate-website.test.mjs
+++ b/scripts/validate-website.test.mjs
@@ -23,27 +23,27 @@ test('public site does not upload installer-click telemetry', async () => {
 
 test('website fallback installer matches the desktop release version', async () => {
   const html = await readFile(websitePath, 'utf8')
-  assert.deepEqual(await collectWebsiteErrors(html, '3.0.0'), [])
+  assert.deepEqual(await collectWebsiteErrors(html, '3.0.1'), [])
 })
 
 test('website validation rejects stale fallback installers', async () => {
-  const html = (await readFile(websitePath, 'utf8')).replaceAll('3.0.0', '0.1.9')
-  const errors = await collectWebsiteErrors(html, '3.0.0')
+  const html = (await readFile(websitePath, 'utf8')).replaceAll('3.0.1', '0.1.9')
+  const errors = await collectWebsiteErrors(html, '3.0.1')
   assert.ok(errors.some(error => error.includes('stale installer version 0.1.9')))
   assert.ok(errors.some(error => error.includes('fallback label')))
 })
 
 test('website exposes canonical SEO and structured data markers', async () => {
   const html = await readFile(websitePath, 'utf8')
-  const errors = await collectWebsiteErrors(html, '3.0.0')
+  const errors = await collectWebsiteErrors(html, '3.0.1')
   assert.deepEqual(errors, [])
 })
 
 test('website validation rejects stale presentation versions', async () => {
   const html = (await readFile(websitePath, 'utf8'))
-    .replace('<title>DeepSeek Harness Desktop 3.0.0', '<title>DeepSeek Harness Desktop 2.2.0')
-    .replace('<h1>DeepSeek Harness<br>Desktop 3.0.0</h1>', '<h1>DeepSeek Harness<br>Desktop 2.1</h1>')
-  const errors = await collectWebsiteErrors(html, '3.0.0')
+    .replace('<title>DeepSeek Harness Desktop 3.0.1', '<title>DeepSeek Harness Desktop 2.2.0')
+    .replace('<h1>DeepSeek Harness<br>Desktop 3.0.1</h1>', '<h1>DeepSeek Harness<br>Desktop 2.1</h1>')
+  const errors = await collectWebsiteErrors(html, '3.0.1')
   assert.ok(errors.some(error => error.includes('page title')))
   assert.ok(errors.some(error => error.includes('page heading')))
 })
@@ -51,7 +51,7 @@ test('website validation rejects stale presentation versions', async () => {
 test('website structured FAQ questions remain visible', async () => {
   const html = (await readFile(websitePath, 'utf8'))
     .replace('<h3>桌面版能和官方 Web 端同时运行吗？</h3>', '<h3>已移除的问题</h3>')
-  const errors = await collectWebsiteErrors(html, '3.0.0')
+  const errors = await collectWebsiteErrors(html, '3.0.1')
   assert.ok(errors.some(error => error.includes('structured FAQ question is not visible')))
 })
 
@@ -59,7 +59,7 @@ test('website validation rejects missing GitHub Star guidance', async () => {
   const html = (await readFile(websitePath, 'utf8'))
     .replaceAll('data-star-cta', 'data-removed-star-cta')
     .replaceAll('data-star-count', 'data-removed-star-count')
-  const errors = await collectWebsiteErrors(html, '3.0.0')
+  const errors = await collectWebsiteErrors(html, '3.0.1')
   assert.ok(errors.some(error => error.includes('GitHub Star CTA')))
   assert.ok(errors.some(error => error.includes('GitHub Star count')))
 })
@@ -69,7 +69,7 @@ test('tracked installer links remain direct GitHub downloads', async () => {
     'data-download-source="hero" href="https://github.com/',
     'data-download-source="hero" href="https://telemetry.example/',
   )
-  const errors = await collectWebsiteErrors(html, '3.0.0')
+  const errors = await collectWebsiteErrors(html, '3.0.1')
   assert.ok(errors.some(error => error.includes('must remain a direct GitHub download')))
 })
 

--- a/website/index.html
+++ b/website/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="zh-CN" data-release-version="3.0.0">
+<html lang="zh-CN" data-release-version="3.0.1">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#0a0a0a">
-    <meta name="description" content="DeepSeek Harness Desktop 3.0.0 是社区维护的开源 Windows AI 编程客户端，提供稳定公开 Schema、受控 Runtime 支持、升级回滚、Stable/Beta 频道、发布 manifest 与用户主动导出的脱敏诊断。">
+    <meta name="description" content="DeepSeek Harness Desktop 3.0.1 是社区维护的开源 Windows AI 编程客户端，提供稳定公开 Schema、受控 Runtime 支持、升级回滚、Stable/Beta 频道、发布 manifest 与用户主动导出的脱敏诊断。">
     <meta name="keywords" content="DeepSeek Harness Desktop,DeepSeek Harness 桌面版,DeepSeek Windows 客户端,Windows AI 编程助手,Harness 下载,开源 AI 客户端">
     <meta name="author" content="DeepSeek Harness Desktop Community">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
@@ -13,8 +13,8 @@
     <meta name="bingbot" content="index, follow, max-image-preview:large">
     <link rel="canonical" href="https://ningbainb.github.io/deepseek-harness-desktop/">
     <link rel="sitemap" type="application/xml" href="https://ningbainb.github.io/deepseek-harness-desktop/sitemap.xml">
-    <meta property="og:title" content="DeepSeek Harness Desktop 3.0.0 开源 Windows 客户端">
-    <meta property="og:description" content="完整 Harness 一键安装；3.0.0 新增稳定公开契约、Runtime 支持政策、迁移回滚与可验证发布。">
+    <meta property="og:title" content="DeepSeek Harness Desktop 3.0.1 开源 Windows 客户端">
+    <meta property="og:description" content="完整 Harness 一键安装；3.0.1 提供稳定公开契约、Runtime 支持政策、迁移回滚与可验证发布。">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://ningbainb.github.io/deepseek-harness-desktop/">
     <meta property="og:site_name" content="DeepSeek Harness Desktop">
@@ -22,10 +22,10 @@
     <meta property="og:image" content="https://ningbainb.github.io/deepseek-harness-desktop/assets/hero-main.png">
     <meta property="og:image:alt" content="DeepSeek Harness Desktop 开源 Windows 桌面客户端界面">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="DeepSeek Harness Desktop 3.0.0 开源 Windows 客户端">
-    <meta name="twitter:description" content="完整 Harness 一键安装；3.0.0 新增稳定公开契约、Runtime 支持政策、迁移回滚与可验证发布。">
+    <meta name="twitter:title" content="DeepSeek Harness Desktop 3.0.1 开源 Windows 客户端">
+    <meta name="twitter:description" content="完整 Harness 一键安装；3.0.1 提供稳定公开契约、Runtime 支持政策、迁移回滚与可验证发布。">
     <meta name="twitter:image" content="https://ningbainb.github.io/deepseek-harness-desktop/assets/hero-main.png">
-    <title>DeepSeek Harness Desktop 3.0.0 - 开源 Windows AI 编程客户端</title>
+    <title>DeepSeek Harness Desktop 3.0.1 - 开源 Windows AI 编程客户端</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -35,7 +35,7 @@
             "@id": "https://ningbainb.github.io/deepseek-harness-desktop/#website",
             "url": "https://ningbainb.github.io/deepseek-harness-desktop/",
             "name": "DeepSeek Harness Desktop",
-            "description": "DeepSeek Harness Desktop 3.0.0 是社区维护的开源 Windows AI 编程客户端，提供完整 Harness、稳定公开契约与 Schema、受控 Runtime 支持、升级回滚、Stable/Beta 频道、可验证发布和用户主动导出的脱敏诊断。",
+            "description": "DeepSeek Harness Desktop 3.0.1 是社区维护的开源 Windows AI 编程客户端，提供完整 Harness、稳定公开契约与 Schema、受控 Runtime 支持、升级回滚、Stable/Beta 频道、可验证发布和用户主动导出的脱敏诊断。",
             "inLanguage": "zh-CN"
           },
           {
@@ -44,15 +44,15 @@
             "name": "DeepSeek Harness Desktop",
             "alternateName": "DeepSeek Harness 桌面版",
             "url": "https://ningbainb.github.io/deepseek-harness-desktop/",
-            "description": "完整保留 Harness Web Surface 的开源 Windows AI 编程客户端。3.0.0 冻结公开契约与 Schema，以受控 Runtime matrix、迁移回滚、Stable/Beta 频道和 release manifest 提供可维护的升级基础。",
+            "description": "完整保留 Harness Web Surface 的开源 Windows AI 编程客户端。3.0.1 冻结公开契约与 Schema，以受控 Runtime matrix、迁移回滚、Stable/Beta 频道和 release manifest 提供可维护的升级基础。",
             "applicationCategory": "DeveloperApplication",
             "applicationSubCategory": "AI coding assistant",
             "operatingSystem": "Windows 10, Windows 11",
-            "softwareVersion": "3.0.0",
+            "softwareVersion": "3.0.1",
             "isAccessibleForFree": true,
-            "downloadUrl": "https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe",
+            "downloadUrl": "https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe",
             "installUrl": "https://ningbainb.github.io/deepseek-harness-desktop/#download",
-            "releaseNotes": "https://github.com/ningbainb/deepseek-harness-desktop/releases/tag/desktop-v3.0.0",
+            "releaseNotes": "https://github.com/ningbainb/deepseek-harness-desktop/releases/tag/desktop-v3.0.1",
             "codeRepository": "https://github.com/ningbainb/deepseek-harness-desktop",
             "license": "https://github.com/ningbainb/deepseek-harness-desktop/blob/main/LICENSE",
             "dateModified": "2026-08-20",
@@ -198,9 +198,9 @@
           <span data-site-theme-label>动感亮色</span>
         </button>
         <a class="nav-community" href="https://qm.qq.com/q/vehlNjaeye" target="_blank" rel="noreferrer"><span>Q</span> 加群</a>
-        <a class="nav-download download-link" data-download-source="nav" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe">
+        <a class="nav-download download-link" data-download-source="nav" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe">
           <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2v10m0 0 4-4m-4 4L6 8M3 15v2h14v-2"/></svg>
-          下载 <span class="release-version">v3.0.0</span>
+          下载 <span class="release-version">v3.0.1</span>
         </a>
       </nav>
     </header>
@@ -211,11 +211,11 @@
         <div class="container hero-inner">
           <div class="hero-copy reveal">
             <p class="overline">DeepSeek Harness Desktop 社区版</p>
-            <h1>DeepSeek Harness<br>Desktop 3.0.0</h1>
+            <h1>DeepSeek Harness<br>Desktop 3.0.1</h1>
             <p class="hero-summary">社区维护的开源 Windows AI 编程客户端：完整保留 Harness Web Surface，并加入稳定公开契约、受控 Runtime 支持、迁移回滚、插件、Skills、主题、移动远程、QQ Bot 与自动更新。</p>
             <p class="hero-summary">支持 Windows 10/11 x64，无需另外安装 Node.js；独立 profile 和端口回退允许桌面版与官方 Web 端同时运行。</p>
             <div class="hero-buttons">
-              <a class="btn btn-primary download-link" data-download-source="hero" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe">
+              <a class="btn btn-primary download-link" data-download-source="hero" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe">
                 <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M2 2h7v7H2V2Zm9 0h7v7h-7V2ZM2 11h7v7H2v-7Zm9 0h7v7h-7v-7Z"/></svg>
                 下载 Windows x64
               </a>
@@ -250,8 +250,8 @@
                   <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M7 6V3h10v10h-3M3 7h10v10H3V7Z"/></svg><span>复制</span>
                 </button>
               </div>
-              <a id="terminal-action" class="terminal-command" data-download-source="terminal" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe" data-download-href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe" data-source-href="https://github.com/ningbainb/deepseek-harness-desktop" aria-label="立即下载 Windows x64 安装包">
-                <code id="terminal-command" data-download-command="下载 DeepSeek Harness Desktop v3.0.0" data-source-command="git clone https://github.com/ningbainb/deepseek-harness-desktop">下载 DeepSeek Harness Desktop v3.0.0</code>
+              <a id="terminal-action" class="terminal-command" data-download-source="terminal" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe" data-download-href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe" data-source-href="https://github.com/ningbainb/deepseek-harness-desktop" aria-label="立即下载 Windows x64 安装包">
+                <code id="terminal-command" data-download-command="下载 DeepSeek Harness Desktop v3.0.1" data-source-command="git clone https://github.com/ningbainb/deepseek-harness-desktop">下载 DeepSeek Harness Desktop v3.0.1</code>
                 <span class="terminal-cta">立即下载</span>
               </a>
               <div class="terminal-meta"><span>Windows 10 / 11</span><span>x64</span><span class="release-size">约 135 MB</span></div>
@@ -291,7 +291,7 @@
       <section class="latest-features" id="latest-features" aria-labelledby="latest-features-title">
         <div class="container">
           <div class="section-title reveal">
-            <span>v3.0.0 平台稳定版</span>
+            <span>v3.0.1 平台稳定版</span>
             <h2 id="latest-features-title">先看稳定承诺，再决定如何升级</h2>
           </div>
           <div class="latest-grid">
@@ -426,7 +426,7 @@
           <div class="install-grid">
             <article class="install-card reveal">
               <h3>Windows 一键安装</h3><p>下载 x64 安装包，应用会自动检查后续更新。</p>
-              <a class="code-line download-link" data-download-source="install" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe"><span class="prompt">$</span><code>DeepSeek Harness Desktop <span class="release-version">v3.0.0</span></code><span class="code-action">下载</span></a>
+              <a class="code-line download-link" data-download-source="install" href="https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe"><span class="prompt">$</span><code>DeepSeek Harness Desktop <span class="release-version">v3.0.1</span></code><span class="code-action">下载</span></a>
             </article>
             <article class="install-card reveal">
               <h3>源码构建</h3><p>克隆完整项目，安装依赖后打包 Windows 桌面应用。</p>
@@ -443,9 +443,9 @@
             <div class="release-copy">
               <div class="release-heading">
                 <span class="release-state">STABLE / 稳定通道</span>
-                <strong class="release-version">v3.0.0</strong>
+                <strong class="release-version">v3.0.1</strong>
               </div>
-              <p>v3.0.0 冻结公开 SDK/Contract/Provider/Schema，采用受控 Runtime matrix 和 patch 政策，提供覆盖 2.3–2.7 的升级/回滚矩阵（legacy browser-localStorage state 需确认且扫描不展示内容/计数；确认后仅复制受支持的保留同源 v1 数据到空 v3 Host ledger，并以 task count/fingerprint 验证且保留原值；origin 未知、缺失或变化时阻断复制并保留恢复指引）、Stable/Beta 频道、release manifest 与默认关闭的遥测边界。</p>
+              <p>v3.0.1 冻结公开 SDK/Contract/Provider/Schema，采用受控 Runtime matrix 和 patch 政策，提供覆盖 2.3–2.7 的升级/回滚矩阵（legacy browser-localStorage state 需确认且扫描不展示内容/计数；确认后仅复制受支持的保留同源 v1 数据到空 v3 Host ledger，并以 task count/fingerprint 验证且保留原值；origin 未知、缺失或变化时阻断复制并保留恢复指引）、Stable/Beta 频道、release manifest 与默认关闭的遥测边界。</p>
               <div class="release-facts">
                 <span><small>发布日期</small><time class="release-date" datetime="2026-08-20">2026-08-20</time></span>
                 <span><small>安装包</small><strong class="release-size">约 135 MiB</strong></span>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -1,6 +1,6 @@
 # DeepSeek Harness Desktop
 
-> DeepSeek Harness Desktop 3.0.0 is a community-maintained, open-source Windows AI coding client for DeepSeek Harness. It preserves the complete Harness Web Surface and adds stable public contracts and schemas, a controlled Runtime support matrix, safe migration and rollback, Stable/Beta channels, release-manifest verification, and user-initiated privacy-redacted diagnostics.
+> DeepSeek Harness Desktop 3.0.1 is a community-maintained, open-source Windows AI coding client for DeepSeek Harness. It preserves the complete Harness Web Surface and adds stable public contracts and schemas, a controlled Runtime support matrix, safe migration and rollback, Stable/Beta channels, release-manifest verification, and user-initiated privacy-redacted diagnostics.
 
 ## What it is
 
@@ -15,8 +15,8 @@
 
 ## Download
 
-- Latest Windows x64 installer: https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.0-x64.exe
-- v3.0.0 release notes and release assets: https://github.com/ningbainb/deepseek-harness-desktop/releases/tag/desktop-v3.0.0
+- Latest Windows x64 installer: https://github.com/ningbainb/deepseek-harness-desktop/releases/latest/download/DeepSeek-Harness-Desktop-Setup-3.0.1-x64.exe
+- v3.0.1 release notes and release assets: https://github.com/ningbainb/deepseek-harness-desktop/releases/tag/desktop-v3.0.1
 
 ## Source and documentation
 
@@ -28,8 +28,8 @@
 ## Key facts
 
 - Supported systems: Windows 10 and Windows 11, x64
-- Current release: v3.0.0
-- v3.0.0 freezes the 1.x SDK/Contract/Provider boundaries and public schemas, limits Stable Runtime to verified `known-good` or `supported` matrix entries, covers the 2.3–2.7 migration matrix by detecting, validating, and snapshotting recognized v2/v3 state while treating legacy browser-localStorage state as confirmation-required and non-disclosing in the scan; after confirmation, supported preserved-origin v1 data can be copied only into an empty v3 Host ledger and verified by task count/fingerprint without removing the original browser value, while an unknown, missing, or changed origin blocks the copy for recovery, and Stable/Beta updates remain separate without automatic downgrades
+- Current release: v3.0.1
+- v3.0.1 freezes the 1.x SDK/Contract/Provider boundaries and public schemas, limits Stable Runtime to verified `known-good` or `supported` matrix entries, covers the 2.3–2.7 migration matrix by detecting, validating, and snapshotting recognized v2/v3 state while treating legacy browser-localStorage state as confirmation-required and non-disclosing in the scan; after confirmation, supported preserved-origin v1 data can be copied only into an empty v3 Host ledger and verified by task count/fingerprint without removing the original browser value, while an unknown, missing, or changed origin blocks the copy for recovery, and Stable/Beta updates remain separate without automatic downgrades
 - Published assets include `SHA256SUMS.txt` and `release-manifest.json`; the manifest reports the actual per-asset signature state. A local or source build may be unsigned and does not establish the state of a published asset
 - Desktop telemetry is disabled by default. Diagnostics are generated only after user confirmation to a selected local location and are redacted to exclude secrets, user content, full prompts, full sessions, tool results, project content, paths, and SSH private keys
 - The public website does not automatically report installer clicks; installer links remain direct GitHub Release downloads


### PR DESCRIPTION
## 摘要（Summary）

准备 DeepSeek Harness Desktop 3.0.1 正式发布，修复 Windows Release Runner 中内置终端长路径被 xterm 换行或滚动后误判超时的问题，并让打包迁移矩阵按当前 Desktop patch 版本核验运行时证据。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：`apps/dsh-desktop`、发布文档、网站版本信息与运行时证据

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch desktop main --prune
git rev-list --left-right --count HEAD...desktop/main
# 修改提交前结果：0 0
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：OpenAI Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改包 README；根 README 中英版本已同步）。

## 贡献者版权声明（Contributor Copyright）

不适用，本 PR 未贡献插件或皮肤。

## 社区插件索引登记（Community Plugin Index）

不适用，本 PR 未新增第三方插件索引项。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm verify
pnpm --dir apps/dsh-desktop pack:win --config.publish.channel=latest
```

结果摘要：

- Node.js 24.19.0 下 `pnpm verify` exit 0。
- Desktop 683 项：682 通过，0 失败，1 项按 Windows Developer Mode 环境跳过。
- 仓库脚本测试 150/150 通过，所有类型检查、运行时依赖、导入边界、耦合审计、Known Good、supported matrix、社区质量、同步、发布说明、网站、聚合、gallery、skin-center、community 与文档门禁通过。
- 全新 3.0.1 Windows x64 未签名安装包构建完成；打包 Runtime、目录选择器、终端、窗口栏、清空 Profile、更新关闭回执、2.3-2.7 迁移矩阵、smoke、`.dshpreset`、`dsh://extensions` 与 Task Board Worktree E2E 全部通过。
- 本地安装器与主程序签名状态均为 `NotSigned`，manifest 和发布说明如实记录 `unsigned`；SHA256/manifest 自校验通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。本 PR 修复 CI/Release 的终端工作目录探针并同步 patch 版本；真实未打包与最终打包终端 E2E 均已通过，用户功能界面未新增视觉行为。