### PR TITLE
fix(release): publish only updater metadata

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -192,6 +192,6 @@ jobs:
           files: |
             apps/dsh-desktop/dist/DeepSeek-Harness-Desktop-Setup-*.exe
             apps/dsh-desktop/dist/DeepSeek-Harness-Desktop-Setup-*.exe.blockmap
-            apps/dsh-desktop/dist/*.yml
+            apps/dsh-desktop/dist/${{ steps.release.outputs.updater_channel }}.yml
             apps/dsh-desktop/dist/SHA256SUMS.txt
             apps/dsh-desktop/dist/release-manifest.json

--- a/apps/dsh-desktop/test/release-manifest.test.mjs
+++ b/apps/dsh-desktop/test/release-manifest.test.mjs
@@ -195,6 +195,8 @@ test('official Desktop tag releases require signing only when certificate materi
   assert.match(workflow, /release-manifest\.json/u)
   assert.match(workflow, /\.signature\.status/u)
   assert.match(workflow, /body_path: apps\/dsh-desktop\/dist\/release-notes\.md/u)
+  assert.match(workflow, /apps\/dsh-desktop\/dist\/\$\{\{ steps\.release\.outputs\.updater_channel \}\}\.yml/u)
+  assert.doesNotMatch(workflow, /apps\/dsh-desktop\/dist\/\*\.yml/u)
   for (const releaseGate of [
     'test:directory-picker:e2e',
     'test:terminal:e2e',


### PR DESCRIPTION
## 摘要（Summary）

修复 Desktop Release 资产通配符误上传 electron-builder `builder-debug.yml` 的问题。发布步骤现在只上传由已验证频道解析出的 `latest.yml` 或 `beta.yml`，并用源代码契约测试禁止恢复宽泛的 `*.yml`。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：Desktop Release workflow 与 release-manifest 契约测试

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch desktop main --prune
git switch -c codex/desktop-release-assets desktop/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：OpenAI Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 贡献者版权声明（Contributor Copyright）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
node --test apps/dsh-desktop/test/release-manifest.test.mjs
pnpm --filter @deepseek-ai/dsh-desktop test
git diff --check
```

结果摘要：

- release-manifest / Release workflow 契约测试 9/9 通过。
- Desktop 683 项：682 通过，0 失败，1 项按环境跳过。
- `git diff --check` 通过。
- 已确认 3.0.1 Release 的误上传文件不含 secret、Token、私钥或证书材料，并已从 Release 精确移除；正式五项资产及哈希保持不变。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。此改动只收紧后续 GitHub Release 的资产选择，不改变桌面应用界面或运行行为。