### PR TITLE
fix(telemetry): classify macOS instead of labelling it windows-other

### DIFF
--- a/apps/dsh-desktop/src/telemetry-events.mjs
+++ b/apps/dsh-desktop/src/telemetry-events.mjs
@@ -55,6 +55,7 @@ function exactFields(value, fields) {
 }
 
 function operatingSystemFamily(platform, release) {
+  if (platform === 'darwin') return 'macos'
   if (platform !== 'win32' || typeof release !== 'string') return 'windows-other'
   const [major, minor, buildText] = release.split('.')
   const build = Number.parseInt(buildText ?? '', 10)

--- a/apps/dsh-desktop/test/telemetry-events.test.mjs
+++ b/apps/dsh-desktop/test/telemetry-events.test.mjs
@@ -33,6 +33,41 @@ test('normalizes only coarse product context dimensions', () => {
   })
 })
 
+test('classifies macOS as its own coarse operating system family', () => {
+  assert.deepEqual(normalizeProductContext({
+    version: '3.0.1',
+    platform: 'darwin',
+    osRelease: '24.6.0',
+    locale: 'zh-CN',
+  }), {
+    appVersion: '3.0.1',
+    channel: 'stable',
+    os: 'macos',
+    language: 'zh',
+  })
+  // 与 Windows 不同，macOS 不按版本细分，避免维护 Darwin 内核版本到 macOS 版本的映射表
+  assert.equal(normalizeProductContext({
+    version: '3.0.1',
+    platform: 'darwin',
+    osRelease: '27.0.0',
+    locale: 'en-US',
+  }).os, 'macos')
+  // 缺少 osRelease 时也必须归到 macos，不能退化成 windows-other
+  assert.equal(normalizeProductContext({
+    version: '3.0.1',
+    platform: 'darwin',
+    osRelease: undefined,
+    locale: 'en-US',
+  }).os, 'macos')
+  // 其余非 Windows 平台的既有归类保持不变（当前没有对应发布目标）
+  assert.equal(normalizeProductContext({
+    version: '3.0.1',
+    platform: 'linux',
+    osRelease: '6.8.0',
+    locale: 'en-US',
+  }).os, 'windows-other')
+})
+
 test('creates exact fixed-shape events and rejects content-like fields', () => {
   const context = normalizeProductContext({
     version: '2.5.0',

--- a/apps/dsh-telemetry-worker/src/index.mjs
+++ b/apps/dsh-telemetry-worker/src/index.mjs
@@ -24,7 +24,7 @@ const DOWNLOAD_CLICK_FIELDS = Object.freeze(['schema', 'source', 'version'])
 const APP_VERSION_PATTERN = /^\d{1,4}\.\d{1,4}\.\d{1,4}(?:-[0-9A-Za-z.-]{1,20})?$/u
 
 const CHANNELS = new Set(['stable', 'prerelease'])
-const OPERATING_SYSTEMS = new Set(['windows-10', 'windows-11', 'windows-other'])
+const OPERATING_SYSTEMS = new Set(['windows-10', 'windows-11', 'windows-other', 'macos'])
 const LANGUAGES = new Set(['zh', 'en', 'other'])
 const DOWNLOAD_SOURCES = new Set(['nav', 'hero', 'terminal', 'install'])
 

--- a/apps/dsh-telemetry-worker/test/worker.test.mjs
+++ b/apps/dsh-telemetry-worker/test/worker.test.mjs
@@ -177,6 +177,23 @@ test('rejects oversized, malformed, and unknown input', async () => {
   assert.equal(invalidEnum.status, 400)
 })
 
+test('accepts the macos operating system family and still rejects unknown ones', async () => {
+  const database = new FakeDatabase()
+  const accepted = await worker.fetch(requestFor({
+    schema: 1,
+    events: [{ ...VALID_EVENT, os: 'macos' }],
+  }), enabledEnvironment(database))
+  assert.equal(accepted.status, 204)
+  assert.equal(database.batches.length, 1)
+  assert.ok(database.batches[0][0].values.includes('macos'))
+
+  const rejected = await worker.fetch(requestFor({
+    schema: 1,
+    events: [{ ...VALID_EVENT, os: 'macos-27' }],
+  }), enabledEnvironment())
+  assert.equal(rejected.status, 400)
+})
+
 test('groups identical events and binds only aggregate dimensions', async () => {
   const database = new FakeDatabase()
   const now = new Date('2026-08-19T23:59:59.000Z')


### PR DESCRIPTION
## 摘要（Summary）

修 `operatingSystemFamily()` 把非 Windows 平台一律归类为 `windows-other` 的问题：`apps/dsh-desktop/src/telemetry-events.mjs` 里该函数没有任何 macOS 分支，非 Windows 客户端的 `os` 维度会被错误统计成 Windows。

单改客户端不够。`apps/dsh-telemetry-worker/src/index.mjs:27` 的 `OPERATING_SYSTEMS` 白名单只有三个 Windows 取值，`validEvent()`（同文件 `:147`）会把未登记的 `os` 整批判为非法并返回 400 —— 那样数据会从「打错标签」变成「直接丢弃」，比原来更糟。所以两侧一并改。

macOS 不按版本细分（Windows 分 10 / 11 / other），理由是避免引入并长期维护 Darwin 内核版本到 macOS 版本的映射表，也不增加聚合维度的基数。其余非 Windows 平台的既有归类保持不变，当前没有对应的发布目标。

Windows 侧行为完全不变。现有测试用例一个未改，只新增两条。

## 涉及包（Affected Packages）

不涉及 `packages/` 下任何包。改动落在 `apps/dsh-desktop` 与 `apps/dsh-telemetry-worker`。

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）

其他：`apps/dsh-desktop`（遥测事件归一化）、`apps/dsh-telemetry-worker`（服务端维度白名单）。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

不勾「面向用户」的原因：改的是遥测内部的粗粒度分类逻辑，没有任何 UI、文案或用户可观察行为的变化。

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git checkout -b macos/telemetry-os-family origin/main
```

基线：`main@33d9d5d`（Merge pull request #45）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Claude Opus 5

使用的编码 Agent 工具：

Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

第 3、5 项说明：本 PR 不新增包目录、不改动任何 README，故不适用；`pnpm docs:check` 仍已运行并通过。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install --frozen-lockfile
node --test test/telemetry-events.test.mjs          # apps/dsh-desktop
node --test test/worker.test.mjs                    # apps/dsh-telemetry-worker
node --test test/*.test.mjs                         # apps/dsh-desktop 全量
pnpm docs:check
git diff --cached --check
```

结果摘要：

- `apps/dsh-desktop/test/telemetry-events.test.mjs`：4 个用例全通过（含新增的 macOS 归类用例）。
- `apps/dsh-telemetry-worker/test/worker.test.mjs`：19 个用例全通过（含新增的白名单用例）。
- `apps/dsh-desktop` 全量：改动前 `tests 683 / pass 660 / fail 13 / skipped 10`，改动后 `tests 684 / pass 661 / fail 13 / skipped 10` —— 新增用例通过，失败数与失败文件集合完全不变。
- `pnpm docs:check` 通过；`git diff --cached --check` 无空白错误。

需要如实说明那 13 个失败：它们在本改动前就已存在，与本 PR 无关，全部来自测试夹具里写死的 Windows 假设，集中在 5 个文件（`runtime-provider` 7 个、`terminal-session` 2 个、`runtime-controller` 2 个、`managed-git-runtime-service` 1 个、`deep-links` 1 个）。典型形态是夹具把 `C:\\...` 当绝对路径传入（POSIX 下 `path.isAbsolute()` 判否）、断言 PATH 用 `;` 拼接、断言 `taskkill.exe` 的反斜杠路径。产品代码本身普遍支持注入 `platform` 参数，所以这些是夹具问题而非产品缺陷。本 PR 没有改动任何现有测试用例。

验证环境：Apple Silicon Mac，macOS 27.0，arm64，Node 24.19.0，pnpm 11.22.0。Windows 侧由本仓 CI 把关。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（遥测内部分类逻辑，无用户可见变更；已在上一节给出两侧单测的前后对比数据）
