### PR TITLE
fix(release): refresh the three lockfile-hash artifacts that keep CI red

### DIFF
--- a/apps/dsh-desktop/runtime-support/known-good.json
+++ b/apps/dsh-desktop/runtime-support/known-good.json
@@ -31,7 +31,7 @@
   },
   "lockfile": {
     "path": "pnpm-lock.yaml",
-    "sha256": "5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a"
+    "sha256": "1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2"
   },
   "provider": {
     "providerId": "dsh-cli-provider-v1",

--- a/apps/dsh-desktop/runtime-support/supported-runtimes.json
+++ b/apps/dsh-desktop/runtime-support/supported-runtimes.json
@@ -55,7 +55,7 @@
         "peers": {},
         "lockfile": {
           "path": "pnpm-lock.yaml",
-          "sha256": "5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a"
+          "sha256": "1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2"
         },
         "slots": [
           "conversation.composer.dock",

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.json
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "desktopVersion": "3.0.1",
   "upstreamVersion": "0.1.1-rc.1",
-  "lockfileSha256": "5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a",
+  "lockfileSha256": "1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2",
   "policy": {
     "controlledImportPrefixes": [
       "apps/dsh-desktop/src/runtime-provider.mjs",

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.md
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.md
@@ -4,7 +4,7 @@ Authoritative Desktop version: 3.0.1.
 
 Stable DSH package version: 0.1.1-rc.1.
 
-Lockfile SHA-256: `5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a`.
+Lockfile SHA-256: `1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2`.
 
 Capability discovery is compatibility evidence only. Renderer surface identity, channel allowlists, and argument validation remain the authorization boundary.
 


### PR DESCRIPTION
## 摘要（Summary）

`a182d23`（fix(ci): correct malformed pnpm patch hunk header）改动了 `pnpm-lock.yaml`，它的 sha256 从 `5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a` 变成了 `1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2`。但仓库里有三份签入的生成产物内嵌了这个哈希，都没有随之重新生成：

| 文件 | 卡住的检查 |
|---|---|
| `apps/dsh-desktop/runtime-support/known-good.json` | `pnpm test:scripts` 里 `scripts/runtime-support.test.mjs:55` 的 `committed Known Good runtime manifest is current` |
| `docs/archive/desktop-2.5-dsh-coupling-audit.json` / `.md` | `pnpm dsh-audit:check` |
| `apps/dsh-desktop/runtime-support/supported-runtimes.json` | `pnpm runtime-support-matrix:check` |

一个根因，三份产物。本 PR 把三份都用仓库自带的生成器重新生成，diff 合计四行，全部只是那一行 sha256，没有手工编辑，不含任何逻辑或依赖变更。

`main` 上两个 workflow 自 2026-08-25 起双双全红，且失败步骤都是最早的那一个：

- `CI` on `main@33d9d5d`：run `32858514136`，唯一失败步骤 `CI checks -> Script tests`，`not ok 110 - committed Known Good runtime manifest is current`。
- `Desktop CI` on `main@33d9d5d`：run `32858514369`，唯一失败步骤 `test -> Run pnpm test:scripts`，同一条断言。

因为 `test:scripts` 排在 `dsh-audit:check` 与 `runtime-support-matrix:check` 之前，job 在那里就中止了，后两个失败一直被遮住。本 PR 第一个 commit 修掉 `test:scripts` 之后，run `32960603249` 才把 `dsh-audit:check` 暴露出来，所以有了第二个 commit。

任何新开的 PR 都会继承这条继承性失败（#48、#49 的 CI checks 都是同一条）。

**一个本 PR 修不了、也不属于本 PR 范围的遗留失败**：`CI checks` 里 `Script tests` 通过之后，会走到更靠后的 `No emoji rule` 步骤，该步骤在仓库自带的 `README.md` 与 `README.en.md` 上各命中 39 处（`U+1F5A5`、`U+2705`、`U+2B50`、`U+2764`、`U+FE0F` 等），见 run `32960603270`。这两个文件本 PR 未改动。这一项同样是先前被 `Script tests` 遮住的，需要单独决定怎么处理（改 README 还是给顶层 README 开豁免），我没有擅自改你的门面文件。

## 涉及包（Affected Packages）

不涉及 `packages/` 下任何包。

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）

其他：`apps/dsh-desktop/runtime-support/known-good.json`、`apps/dsh-desktop/runtime-support/supported-runtimes.json`、`docs/archive/desktop-2.5-dsh-coupling-audit.json`、`docs/archive/desktop-2.5-dsh-coupling-audit.md`（四个文件，各一行哈希）。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git checkout -b macos/runtime-support-manifest origin/main
```

基线：`main@33d9d5d`（Merge pull request #45）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Claude Opus 5

使用的编码 Agent 工具：

Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

第 3、5 项说明：本 PR 不新增包目录、不改动任何 README，故不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install --frozen-lockfile
pnpm runtime-support:write
node scripts/audit-dsh-coupling.mjs --write
node scripts/generate-runtime-support-matrix.mjs --write
pnpm test:scripts
pnpm dsh-audit:check
pnpm runtime-support:check
pnpm runtime-support-matrix:check
pnpm runtime-deps:check
pnpm dsh-imports:check
pnpm docs:check
git diff --check
```

结果摘要：

- 三个生成器合计只产生四行 diff，每行都是同一处 sha256（`git diff --stat`：`4 files changed, 4 insertions(+), 4 deletions(-)`）。
- `pnpm test:scripts`：改动前 `committed Known Good runtime manifest is current` 失败；改动后 `tests 150 / pass 150 / fail 0`。
- `pnpm dsh-audit:check` 输出 `DSH coupling audit is current`；`pnpm runtime-support:check` 输出 `Known Good runtime manifest is current`；`pnpm runtime-support-matrix:check` 输出 `Supported runtime matrix is current`。
- 按 `desktop-ci.yml` 的步骤顺序，把其中 14 个非 e2e 的 `:check` 步骤（`runtime-deps` / `dsh-imports` / `dsh-audit` / `runtime-support` / `runtime-support-matrix` / `community-plugin-quality` / `sync-shared` / `release:notes` / `website` / `aggregate` / `gallery` / `skin-center` / `community` / `docs`）逐个跑了一遍，14/14 通过。
- `git diff --check` 无空白错误。

验证环境：Apple Silicon Mac，macOS 27.0，arm64，Node 24.19.0，pnpm 11.22.0。这四份产物的内容由 `pnpm-lock.yaml` 与包元数据确定，与生成它们的操作系统无关；Windows 侧仍由本仓 CI 把关。Playwright e2e 四项与 `pnpm typecheck` / `pnpm test` 未在本地复跑，交由 CI 的 windows-latest 验证。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（发布证据清单里的哈希对齐，无用户可见变更）
