### PR TITLE
fix(runtime): terminate the POSIX runtime process group, not just the child

### DIFF
--- a/apps/dsh-desktop/src/runtime-controller.mjs
+++ b/apps/dsh-desktop/src/runtime-controller.mjs
@@ -163,17 +163,37 @@ export function formatRuntimeExit(code, signal, { platform = process.platform } 
   return 'runtime exited unexpectedly without an exit code'
 }
 
+// Windows terminates the whole tree through `taskkill /T`. POSIX has no such
+// flag, so the runtime child is spawned as a process-group leader (`detached`)
+// and the signal goes to the negated pid, which reaches every descendant the
+// child started. Signalling only the direct child leaves the grandchildren to
+// be reparented to pid 1, where nothing ever reaps them.
+function signalChildProcessGroup(child, signal, processKill) {
+  if (!Number.isInteger(child.pid) || child.pid <= 0) return false
+  try {
+    processKill(-child.pid, signal)
+    return true
+  } catch (error) {
+    // ESRCH means the group is already gone; EPERM means the child never became
+    // a group leader. Both fall back to the direct child instead of propagating,
+    // so a group that cannot be signalled never turns into no signal at all.
+    if (error?.code !== 'ESRCH' && error?.code !== 'EPERM') throw error
+    return false
+  }
+}
+
 export function terminateChildProcessTree(
   child,
   {
     platform = process.platform,
     systemRoot = process.env.SystemRoot,
     execFileFn = execFile,
+    processKill = process.kill,
   } = {},
 ) {
   if (!child || child.exitCode !== null) return Promise.resolve()
   if (platform !== 'win32' || !Number.isInteger(child.pid) || child.pid <= 0) {
-    child.kill('SIGTERM')
+    if (!signalChildProcessGroup(child, 'SIGTERM', processKill)) child.kill('SIGTERM')
     return Promise.resolve()
   }
   const executable = systemRoot ? join(systemRoot, 'System32', 'taskkill.exe') : 'taskkill.exe'
@@ -185,6 +205,22 @@ export function terminateChildProcessTree(
       (error) => error ? reject(error) : resolve(),
     )
   })
+}
+
+/**
+ * Escalation used when the graceful tree shutdown fails or times out. On
+ * Windows the graceful path is already `taskkill /F`, so the direct kill is the
+ * only remaining lever; on POSIX the escalation has to reach the group too, or
+ * the force path leaks exactly the descendants the graceful path just tried to
+ * collect.
+ */
+export function forceKillChildProcessTree(
+  child,
+  { platform = process.platform, processKill = process.kill } = {},
+) {
+  if (!child || child.exitCode !== null) return
+  if (platform !== 'win32' && signalChildProcessGroup(child, 'SIGKILL', processKill)) return
+  child.kill('SIGKILL')
 }
 
 export async function probeHttpReady(
@@ -236,6 +272,7 @@ export class DshRuntimeController extends EventEmitter {
     schedule = setTimeout,
     cancelSchedule = clearTimeout,
     terminateProcessTree = terminateChildProcessTree,
+    forceTerminateProcessTree = forceKillChildProcessTree,
     pathEntries = [],
     patchFiles = [],
     patchFilesProvider,
@@ -264,6 +301,7 @@ export class DshRuntimeController extends EventEmitter {
     this.schedule = schedule
     this.cancelSchedule = cancelSchedule
     this.terminateProcessTree = terminateProcessTree
+    this.forceTerminateProcessTree = forceTerminateProcessTree
     this.pathEntries = pathEntries
     this.patchFiles = validateRuntimePatchFiles(patchFiles)
     if (patchFilesProvider !== undefined && typeof patchFilesProvider !== 'function') {
@@ -446,6 +484,10 @@ export class DshRuntimeController extends EventEmitter {
           shell: false,
           stdio: ['ignore', 'pipe', 'pipe'],
           windowsHide: true,
+          // Makes the child a POSIX process-group leader so shutdown can signal
+          // the whole group. Windows keeps its existing semantics: `detached`
+          // there means a new console, and `taskkill /T` already walks the tree.
+          detached: this.platform !== 'win32',
         },
       )
       this.child = child
@@ -538,6 +580,28 @@ export class DshRuntimeController extends EventEmitter {
     this.#terminateFailedStartupChild(redactionToken)
   }
 
+  // Single exit for every SIGKILL escalation, so the POSIX group semantics
+  // cannot drift apart from the graceful path in one branch and not another.
+  // Every caller is either a timer or a catch block, so an unexpected errno
+  // must not escape here: that would take down the app instead of the runtime.
+  #forceKillChild(child, redactionToken = this.workspaceFileOpenToken) {
+    try {
+      this.forceTerminateProcessTree(child, { platform: this.platform })
+    } catch (error) {
+      this.#appendDiagnostic(
+        `[process] force kill failed: ${this.#errorMessage(error, redactionToken)}`,
+        redactionToken,
+      )
+      // The group signal never reached the child, so the direct kill is the
+      // last lever left.
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // Nothing left to escalate to; the exit handler still reports the state.
+      }
+    }
+  }
+
   #terminateFailedStartupChild(redactionToken = this.workspaceFileOpenToken) {
     const child = this.child
     if (child === undefined || child.exitCode !== null || this.failedStartupCleanup) return
@@ -552,7 +616,7 @@ export class DshRuntimeController extends EventEmitter {
     }
 
     const forceTimer = this.schedule(() => {
-      if (child.exitCode === null) child.kill('SIGKILL')
+      if (child.exitCode === null) this.#forceKillChild(child)
     }, this.shutdownTimeoutMs)
     forceTimer?.unref?.()
 
@@ -570,7 +634,7 @@ export class DshRuntimeController extends EventEmitter {
           `[process] failed-startup tree shutdown failed: ${this.#errorMessage(error, redactionToken)}`,
           redactionToken,
         )
-        if (child.exitCode === null) child.kill('SIGKILL')
+        if (child.exitCode === null) this.#forceKillChild(child)
       })
   }
 
@@ -702,7 +766,7 @@ export class DshRuntimeController extends EventEmitter {
     const exited = new Promise((resolve) => {
       this.stopResolver = resolve
     })
-    const forceTimer = this.schedule(() => child.kill('SIGKILL'), this.shutdownTimeoutMs)
+    const forceTimer = this.schedule(() => this.#forceKillChild(child), this.shutdownTimeoutMs)
     try {
       await this.terminateProcessTree(child)
     } catch (error) {
@@ -710,7 +774,7 @@ export class DshRuntimeController extends EventEmitter {
         `[process] process-tree shutdown failed: ${this.#errorMessage(error, redactionToken)}`,
         redactionToken,
       )
-      child.kill('SIGKILL')
+      this.#forceKillChild(child)
     }
     await exited
     this.cancelSchedule(forceTimer)

--- a/apps/dsh-desktop/test/runtime-controller.test.mjs
+++ b/apps/dsh-desktop/test/runtime-controller.test.mjs
@@ -17,6 +17,7 @@ import {
   computeRestartDelay,
   createRuntimeInvocation,
   formatRuntimeExit,
+  forceKillChildProcessTree,
   parseDshReadyUrl,
   probeHttpReady,
   terminateChildProcessTree,
@@ -832,4 +833,218 @@ test('controller fails preflight without spawning or scheduling an automatic res
   assert.equal(controller.status.state, 'crashed')
   assert.equal(spawnCalls, 0)
   assert.equal(scheduleCalls, 0)
+})
+
+test('POSIX shutdown signals the runtime process group, not just the direct child', async () => {
+  const signals = []
+  const child = {
+    pid: 43125,
+    exitCode: null,
+    kill: (signal) => signals.push({ direct: signal }),
+  }
+  await terminateChildProcessTree(child, {
+    platform: 'darwin',
+    processKill: (pid, signal) => signals.push({ pid, signal }),
+  })
+  // The negated pid is the whole group: the runtime plus everything it spawned.
+  assert.deepEqual(signals, [{ pid: -43125, signal: 'SIGTERM' }])
+})
+
+test('POSIX shutdown falls back to the direct child when the group cannot be signalled', async () => {
+  for (const code of ['ESRCH', 'EPERM']) {
+    const signals = []
+    const child = {
+      pid: 43125,
+      exitCode: null,
+      kill: (signal) => signals.push({ direct: signal }),
+    }
+    await terminateChildProcessTree(child, {
+      platform: 'darwin',
+      processKill: () => {
+        const error = new Error(code)
+        error.code = code
+        throw error
+      },
+    })
+    // A group that cannot be signalled must never become no signal at all.
+    assert.deepEqual(signals, [{ direct: 'SIGTERM' }], `fallback for ${code}`)
+  }
+})
+
+test('POSIX shutdown propagates unexpected process-kill failures instead of swallowing them', () => {
+  const child = { pid: 43125, exitCode: null, kill: () => {} }
+  // Only ESRCH and EPERM mean "no group to signal". Anything else is a real
+  // fault and must surface, not be mistaken for a completed shutdown. The throw
+  // is synchronous because the POSIX branch never awaits anything.
+  assert.throws(
+    () => terminateChildProcessTree(child, {
+      platform: 'darwin',
+      processKill: () => {
+        const error = new Error('EINVAL')
+        error.code = 'EINVAL'
+        throw error
+      },
+    }),
+    /EINVAL/,
+  )
+})
+
+test('force kill surfaces an unexpected errno rather than reporting a completed kill', () => {
+  const seen = []
+  assert.throws(() => forceKillChildProcessTree(
+    { pid: 43125, exitCode: null, kill: (signal) => seen.push(signal) },
+    {
+      platform: 'darwin',
+      processKill: () => {
+        const error = new Error('EINVAL')
+        error.code = 'EINVAL'
+        throw error
+      },
+    },
+  ), /EINVAL/)
+  // The direct kill is the controller's fallback, not this function's: the
+  // caller has to decide whether an unexpected errno is recoverable.
+  assert.deepEqual(seen, [])
+})
+
+test('a failing force kill is contained: the controller logs it and still kills the child', async () => {
+  const diagnostics = []
+  const child = new FakeChild()
+  const controller = new DshRuntimeController({
+    cliPath: 'dsh-bin.js',
+    cwd: process.cwd(),
+    dshHome: '/isolated-home',
+    platform: 'darwin',
+    spawnProcess: () => child,
+    logStore: { append: async (line) => { diagnostics.push(line) } },
+    probeReady: async () => {},
+    // The graceful path fails, so the escalation runs; the escalation then
+    // throws the way an unexpected errno would.
+    terminateProcessTree: async () => { throw new Error('group shutdown unavailable') },
+    forceTerminateProcessTree: () => {
+      const error = new Error('EINVAL')
+      error.code = 'EINVAL'
+      throw error
+    },
+  })
+  const ready = controller.start()
+  child.stdout.write('dsh web: http://127.0.0.1:43125\n')
+  await ready
+  // A throwing escalation must not reject stop(): timers and catch blocks are
+  // the only callers, and an escape there would take down the app.
+  await controller.stop()
+  assert.equal(child.killed, true)
+  assert.ok(
+    diagnostics.some((line) => line.includes('force kill failed') && line.includes('EINVAL')),
+    `expected a contained force-kill diagnostic, saw ${JSON.stringify(diagnostics)}`,
+  )
+})
+
+test('POSIX shutdown skips the group signal when the child has no usable pid', async () => {
+  for (const pid of [undefined, 0, -1, 1.5]) {
+    const signals = []
+    const child = { pid, exitCode: null, kill: (signal) => signals.push({ direct: signal }) }
+    await terminateChildProcessTree(child, {
+      platform: 'darwin',
+      processKill: () => { throw new Error('process group must not be signalled') },
+    })
+    assert.deepEqual(signals, [{ direct: 'SIGTERM' }], `pid ${String(pid)}`)
+  }
+})
+
+test('Windows shutdown never reaches for a POSIX process group', async () => {
+  const calls = []
+  const child = { pid: 43125, exitCode: null, kill: (signal) => calls.push({ direct: signal }) }
+  await terminateChildProcessTree(child, {
+    platform: 'win32',
+    systemRoot: 'C:\\Windows',
+    execFileFn: (executable, args, options, callback) => {
+      calls.push({ executable, args })
+      callback(null)
+    },
+    // Reaching for a process group on Windows would be the regression this
+    // whole change has to avoid, so the injected kill is a tripwire.
+    processKill: () => { throw new Error('taskkill owns the Windows tree') },
+  })
+  assert.equal(calls.length, 1)
+  // The path separator is whatever `path.join` produces on the host, which is
+  // why only the executable name is asserted here.
+  assert.match(calls[0].executable, /taskkill\.exe$/)
+  assert.deepEqual(calls[0].args, ['/PID', '43125', '/T', '/F'])
+})
+
+test('force kill escalates to the POSIX process group and keeps the Windows direct kill', () => {
+  const posix = []
+  forceKillChildProcessTree(
+    { pid: 43125, exitCode: null, kill: (signal) => posix.push({ direct: signal }) },
+    { platform: 'darwin', processKill: (pid, signal) => posix.push({ pid, signal }) },
+  )
+  assert.deepEqual(posix, [{ pid: -43125, signal: 'SIGKILL' }])
+
+  const windows = []
+  forceKillChildProcessTree(
+    { pid: 43125, exitCode: null, kill: (signal) => windows.push({ direct: signal }) },
+    { platform: 'win32', processKill: () => { throw new Error('not on Windows') } },
+  )
+  assert.deepEqual(windows, [{ direct: 'SIGKILL' }])
+
+  const fallback = []
+  forceKillChildProcessTree(
+    { pid: 43125, exitCode: null, kill: (signal) => fallback.push({ direct: signal }) },
+    {
+      platform: 'darwin',
+      processKill: () => {
+        const error = new Error('ESRCH')
+        error.code = 'ESRCH'
+        throw error
+      },
+    },
+  )
+  assert.deepEqual(fallback, [{ direct: 'SIGKILL' }])
+})
+
+test('force kill leaves an already exited child alone', () => {
+  let touched = false
+  forceKillChildProcessTree(
+    { pid: 43125, exitCode: 0, kill: () => { touched = true } },
+    { platform: 'darwin', processKill: () => { touched = true } },
+  )
+  forceKillChildProcessTree(undefined, { platform: 'darwin' })
+  assert.equal(touched, false)
+})
+
+test('runtime child becomes a process-group leader on POSIX but not on Windows', async () => {
+  const observed = []
+  const run = async (platform) => {
+    const child = new FakeChild()
+    const controller = new DshRuntimeController({
+      cliPath: 'dsh-bin.js',
+      cwd: process.cwd(),
+      dshHome: platform === 'win32' ? 'C:\\isolated-home' : '/isolated-home',
+      platform,
+      spawnProcess: (_executable, _arguments, options) => {
+        observed.push({ platform, detached: options.detached })
+        return child
+      },
+      logStore: { append: async () => {} },
+      probeReady: async () => {},
+      // Terminate for real so stop() resolves on the child's exit instead of
+      // waiting out the shutdown timeout on every platform under test.
+      terminateProcessTree: async (target) => { target.kill() },
+    })
+    const ready = controller.start()
+    child.stdout.write('dsh web: http://127.0.0.1:43125\n')
+    await ready
+    await controller.stop()
+  }
+  await run('darwin')
+  await run('linux')
+  await run('win32')
+  assert.deepEqual(observed, [
+    { platform: 'darwin', detached: true },
+    { platform: 'linux', detached: true },
+    // `detached` on Windows means a new console, and `taskkill /T` already
+    // walks the tree, so the Windows spawn must stay attached.
+    { platform: 'win32', detached: false },
+  ])
 })

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.json
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "desktopVersion": "3.0.1",
   "upstreamVersion": "0.1.1-rc.1",
-  "lockfileSha256": "5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a",
+  "lockfileSha256": "1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2",
   "policy": {
     "controlledImportPrefixes": [
       "apps/dsh-desktop/src/runtime-provider.mjs",
@@ -4036,13 +4036,13 @@
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/src/runtime-controller.mjs",
-      "line": 419,
+      "line": 457,
       "operation": "DSH_HOME"
     },
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/src/runtime-controller.mjs",
-      "line": 420,
+      "line": 458,
       "operation": "DSH_PROFILE"
     },
     {
@@ -6628,7 +6628,7 @@
     {
       "category": "profile-home",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 288,
+      "line": 289,
       "operation": "DSH_PROFILE"
     },
     {
@@ -8218,109 +8218,103 @@
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 282,
+      "line": 283,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 305,
+      "line": 306,
       "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 344,
+      "line": 345,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 386,
+      "line": 387,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 392,
+      "line": 393,
       "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 394,
+      "line": 395,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 402,
+      "line": 403,
       "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 419,
+      "line": 420,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 457,
+      "line": 458,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 505,
+      "line": 506,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 538,
+      "line": 539,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 546,
+      "line": 547,
       "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 567,
+      "line": 568,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 577,
+      "line": 578,
       "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 596,
+      "line": 597,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 618,
+      "line": 619,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 644,
-      "operation": "start"
-    },
-    {
-      "category": "runtime-lifecycle",
-      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 648,
+      "line": 645,
       "operation": "start"
     },
     {
@@ -8332,38 +8326,38 @@
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 661,
-      "operation": "stop"
-    },
-    {
-      "category": "runtime-lifecycle",
-      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 691,
+      "line": 650,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 696,
+      "line": 662,
+      "operation": "stop"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 692,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
       "line": 697,
-      "operation": "stop"
-    },
-    {
-      "category": "runtime-lifecycle",
-      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 739,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 745,
+      "line": 698,
       "operation": "stop"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 740,
+      "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
@@ -8375,25 +8369,55 @@
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
       "line": 747,
-      "operation": "start"
-    },
-    {
-      "category": "runtime-lifecycle",
-      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 763,
       "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 793,
+      "line": 748,
       "operation": "start"
     },
     {
       "category": "runtime-lifecycle",
       "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
-      "line": 831,
+      "line": 764,
+      "operation": "stop"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 794,
       "operation": "start"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 832,
+      "operation": "start"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 930,
+      "operation": "start"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 935,
+      "operation": "stop"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 1035,
+      "operation": "start"
+    },
+    {
+      "category": "runtime-lifecycle",
+      "path": "apps/dsh-desktop/test/runtime-controller.test.mjs",
+      "line": 1038,
+      "operation": "stop"
     },
     {
       "category": "runtime-lifecycle",

--- a/docs/archive/desktop-2.5-dsh-coupling-audit.md
+++ b/docs/archive/desktop-2.5-dsh-coupling-audit.md
@@ -4,7 +4,7 @@ Authoritative Desktop version: 3.0.1.
 
 Stable DSH package version: 0.1.1-rc.1.
 
-Lockfile SHA-256: `5e97bbb68ab761e93d9d4ed0c0878755b9c6e94fdd45158230bd54175883f02a`.
+Lockfile SHA-256: `1ca1c0f7747e72989e51a77adc14264e83284b1da8cb8d940d5065ed644906a2`.
 
 Capability discovery is compatibility evidence only. Renderer surface identity, channel allowlists, and argument validation remain the authorization boundary.
 
@@ -558,8 +558,8 @@ Capability discovery is compatibility evidence only. Renderer surface identity, 
 | profile-home | apps/dsh-desktop/src/profile.mjs | 1039 | profileDir |
 | profile-home | apps/dsh-desktop/src/profile.mjs | 1090 | resolveRuntimePackages |
 | profile-home | apps/dsh-desktop/src/profile.mjs | 1139 | resolveDshCliPath |
-| profile-home | apps/dsh-desktop/src/runtime-controller.mjs | 419 | DSH_HOME |
-| profile-home | apps/dsh-desktop/src/runtime-controller.mjs | 420 | DSH_PROFILE |
+| profile-home | apps/dsh-desktop/src/runtime-controller.mjs | 457 | DSH_HOME |
+| profile-home | apps/dsh-desktop/src/runtime-controller.mjs | 458 | DSH_PROFILE |
 | profile-home | apps/dsh-desktop/src/runtime-provider.mjs | 193 | profileDir |
 | profile-home | apps/dsh-desktop/src/runtime-provider.mjs | 197 | profileDir |
 | profile-home | apps/dsh-desktop/src/runtime-provider.mjs | 198 | profileDir |
@@ -990,7 +990,7 @@ Capability discovery is compatibility evidence only. Renderer surface identity, 
 | profile-home | apps/dsh-desktop/test/qqbot.test.mjs | 25 | profileDir |
 | profile-home | apps/dsh-desktop/test/qqbot.test.mjs | 27 | profileDir |
 | profile-home | apps/dsh-desktop/test/qqbot.test.mjs | 32 | profileDir |
-| profile-home | apps/dsh-desktop/test/runtime-controller.test.mjs | 288 | DSH_PROFILE |
+| profile-home | apps/dsh-desktop/test/runtime-controller.test.mjs | 289 | DSH_PROFILE |
 | profile-home | apps/dsh-desktop/test/runtime-integration.test.mjs | 24 | ensureDesktopProfile |
 | profile-home | apps/dsh-desktop/test/runtime-integration.test.mjs | 25 | resolveDshCliPath |
 | profile-home | apps/dsh-desktop/test/runtime-integration.test.mjs | 91 | profileDir |
@@ -1255,36 +1255,40 @@ Capability discovery is compatibility evidence only. Renderer surface identity, 
 | runtime-lifecycle | apps/dsh-desktop/test/background-scheduler-runtime.test.mjs | 69 | start |
 | runtime-lifecycle | apps/dsh-desktop/test/migration-runtime-bridge.test.mjs | 41 | start |
 | runtime-lifecycle | apps/dsh-desktop/test/migration-runtime-bridge.test.mjs | 86 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 282 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 305 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 344 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 386 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 392 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 394 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 402 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 419 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 457 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 505 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 538 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 546 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 567 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 577 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 596 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 618 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 644 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 648 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 283 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 306 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 345 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 387 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 393 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 395 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 403 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 420 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 458 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 506 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 539 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 547 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 568 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 578 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 597 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 619 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 645 | start |
 | runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 649 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 661 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 691 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 696 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 697 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 739 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 745 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 650 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 662 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 692 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 697 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 698 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 740 | start |
 | runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 746 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 747 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 763 | stop |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 793 | start |
-| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 831 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 747 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 748 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 764 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 794 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 832 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 930 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 935 | stop |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 1035 | start |
+| runtime-lifecycle | apps/dsh-desktop/test/runtime-controller.test.mjs | 1038 | stop |
 | runtime-lifecycle | apps/dsh-desktop/test/runtime-integration.test.mjs | 568 | start |
 | runtime-lifecycle | apps/dsh-desktop/test/runtime-integration.test.mjs | 608 | start |
 | runtime-lifecycle | apps/dsh-desktop/test/runtime-integration.test.mjs | 711 | stop |


### PR DESCRIPTION
## 摘要（Summary）

`apps/dsh-desktop/src/runtime-controller.mjs` 的 `terminateChildProcessTree()` 在 Windows 上用 `taskkill /PID <pid> /T /F`，`/T` 会终止整棵进程树；但在其他平台上只有一句 `child.kill('SIGTERM')`，**只给直接子进程发信号**。

Runtime 子进程正是 Agent 工具调用起进程的那一层，所以在 macOS / Linux 上，它的孙进程在 Runtime 停止后会存活下来并被 pid 1 收养，没人回收。

改动前在 macOS 27.0 / arm64 上的实测：

```
子进程   pid=40070  终止前存活=true  终止后存活=false
孙进程   终止前 pid=40071 ppid=40070
孙进程   终止后 pid=40071 ppid=1        <- 被 launchd 收养，孤儿
```

`ppid` 从 40070 变成 1 是孤儿的确证。

改法：Runtime 子进程在非 win32 上以进程组组长身份启动（`detached`），随后 graceful 路径与四处 SIGKILL 升级路径统一把信号发给取负的 pid，从而覆盖它的全部后代。

三条实现细节，都是从实测里读出来的而不是猜的：

- `ESRCH`（进程组已空）与 `EPERM`（子进程不是组长）**退回**到只给直接子进程发信号 —— 否则原本还能杀掉直接子进程的场景会退化成完全不杀。其余 errno 照常抛出，不能把真故障误当作"已完成的终止"。
- 四处 SIGKILL 升级点全部收敛到一个私有出口。它们的调用方全是定时器或 catch 块，所以那个出口会兜住异常并回退到直接 kill：让意外 errno 从定时器里逃出去会带崩应用，而不是带走 Runtime。
- **Windows 行为完全不变，并且有用例把这一点钉住**：`detached` 在 Windows 上语义是"新建 console"，而 `taskkill /T` 本来就走树，所以 Windows 侧的 spawn 保持 attached，且注入的 `processKill` 是个 tripwire —— 一旦 Windows 分支去碰进程组，用例立刻失败。

改动后同一套复现脚本报告零残留。

## 涉及包（Affected Packages）

不涉及 `packages/` 下任何包。

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）

其他：`apps/dsh-desktop/src/runtime-controller.mjs`、`apps/dsh-desktop/test/runtime-controller.test.mjs`，以及重新生成的 `docs/archive/desktop-2.5-dsh-coupling-audit.json` / `.md`。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git checkout -b macos/posix-process-group-kill origin/main
```

基线：`main@33d9d5d`（Merge pull request #45）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Claude Opus 5

使用的编码 Agent 工具：

Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

第 3、5 项说明：本 PR 不新增包目录、不改动任何 README，故不适用。

**未改动任何现有测试用例**，只新增 10 个。唯一对现有测试文件的非新增改动是 import 行加了一个符号。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/repro-orphan-grandchild.mjs             # 改动前行为
node scripts/repro-orphan-grandchild.mjs --control   # 手动对照
node scripts/repro-orphan-grandchild.mjs --product   # 改动后行为
node --test apps/dsh-desktop/test/runtime-controller.test.mjs
pnpm --filter @deepseek-ai/dsh-desktop test
pnpm typecheck
pnpm test:scripts
pnpm dsh-imports:check
pnpm dsh-audit:check
pnpm runtime-deps:check
pnpm docs:check
pnpm aggregate:check
git diff --check
```

结果摘要：

- **孤儿进程三组对照**（复现脚本直接调用产品代码导出的函数，不搭整个应用）：

  | 组 | spawn 选项 | 终止方式 | 孙进程 |
  |---|---|---|---|
  | 改动前 | 不带 `detached` | 产品 `terminateChildProcessTree` | **残留 1 个，ppid 变成 1** |
  | 手动对照 | `detached: true` | 裸 `process.kill(-pid, 'SIGTERM')` | 0 个 |
  | 改动后 | `detached: true` | 产品 `terminateChildProcessTree` | **0 个** |

  中间那组存在的意义是证明检测逻辑不是恒真的：如果三组都报"有残留"，那"有残留"就不是缺陷的证据而是检测器的 bug。

- `node --test apps/dsh-desktop/test/runtime-controller.test.mjs`：`tests 38 / pass 34 / fail 2 / skipped 2`，耗时 55ms。新增的 10 个全部通过。
- `pnpm --filter @deepseek-ai/dsh-desktop test`：`tests 693 / pass 670 / fail 13 / skipped 10`。**改动前的同机基线是 pass 660 / fail 13 / skipped 10** —— 正好多出新增的 10 个通过，失败集合一个不多一个不少。
- 那 13 个失败**在未改动的上游代码上同样失败**（用 `git show <baseline>:...` 取出原始文件跑过基线对照），全部来自测试夹具里写死的 Windows 假设（夹具把 `C:\...` 当绝对路径传入、断言 PATH 用 `;` 拼接、断言反斜杠路径等）。其中 `runtime-controller` 那 2 个就是本文件里的既有用例，与本 PR 无关。
- `pnpm typecheck` / `test:scripts` / `dsh-imports:check` / `dsh-audit:check` / `runtime-deps:check` / `docs:check` / `aggregate:check` 全部通过；`git diff --check` 无空白错误。

验证环境：Apple Silicon Mac，macOS 27.0，arm64，Node 24.19.0，pnpm 11.22.0。Playwright e2e 四项与 Windows 侧行为未在本地复跑，交由本仓 CI 的 windows-latest 验证 —— Windows 分支的不变性由新增用例在任一平台上断言。

## 需要说明的两件事

**1. 重新生成了 DSH 耦合审计。** `docs/archive/desktop-2.5-dsh-coupling-audit.json` / `.md` 记录了每个 seam 的**行号**，本 PR 在 `runtime-controller.mjs` 里加了约 50 行，把该文件所有 seam 的行号都推移了，`pnpm dsh-audit:check` 因此变红。产物由 `node scripts/audit-dsh-coupling.mjs --write` 重新生成，没有手工编辑。diff 里除行号外还有两类内容：新增用例调用 `controller.start()` / `controller.stop()` 带来的 `runtime-lifecycle` seam 记录，以及下面这一条。

**2. 与 #50 有一行重叠。** 审计产物内嵌 `lockfileSha256`，全量重新生成时会连带把它从 `5e97bbb…` 更新到 `1ca1c0f…` —— 这与 #50 修的是同一处、同一个值。两个 PR 任意顺序合入都不冲突（改成的内容逐字相同）。本 PR 没有触碰 `known-good.json` 与 `supported-runtimes.json`，那两份仍归 #50。

另外提醒一个行为变化：`detached` 让 Runtime 子进程脱离父进程的前台进程组，因此在 `pnpm desktop:dev` 里按 Ctrl-C 时，SIGINT 不再直接抵达 Runtime 子进程，需要走应用自身的退出路径（本 PR 修好的那条）来回收。这只影响开发时的终端习惯，不影响打包后的应用。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（进程生命周期修复，无界面变更；行为证据是上面那张三组对照表里的 `ps` 输出）
