### PR TITLE
fix(managed-git): accept the version suffix stock macOS reports

### DIFF
--- a/apps/dsh-desktop/src/managed-git.mjs
+++ b/apps/dsh-desktop/src/managed-git.mjs
@@ -403,8 +403,15 @@ function normalizedProbeTimeout(value) {
   return value
 }
 
+// Some builds append a vendor suffix after the version on the same line, for
+// example Apple's `git version 2.50.1 (Apple Git-155)`, which ships with the
+// Xcode Command Line Tools and is therefore what a stock macOS reports. The
+// suffix is tolerated but never returned, and it has to be separated by
+// horizontal whitespace so a malformed version can never be truncated into a
+// valid-looking one. The captured token is still checked against
+// GIT_VERSION_PATTERN, so what this accepts as a version is unchanged.
 function parseGitVersion(output) {
-  const match = /(?:^|\r?\n)git version ([0-9][0-9A-Za-z.-]{0,79})(?:\r?\n|$)/iu.exec(output)
+  const match = /(?:^|\r?\n)git version ([0-9][0-9A-Za-z.-]{0,79})(?:[^\S\r\n][^\r\n]{0,199})?(?:\r?\n|$)/iu.exec(output)
   if (match === null || !GIT_VERSION_PATTERN.test(match[1])) return null
   return match[1]
 }

--- a/apps/dsh-desktop/test/managed-git.test.mjs
+++ b/apps/dsh-desktop/test/managed-git.test.mjs
@@ -415,3 +415,39 @@ test('managed Git retries a transient Windows activation lock before publishing 
     await rm(root, { recursive: true, force: true })
   }
 })
+
+test('system Git probe accepts the vendor suffix that stock macOS reports', async () => {
+  // Apple's git ships with the Xcode Command Line Tools, so this is what a
+  // stock macOS prints. Rejecting it made every such machine look like it had
+  // no system Git at all.
+  const apple = await probeSystemGit({ spawn: successfulGitSpawn('2.50.1 (Apple Git-155)'), timeoutMs: 50 })
+  assert.deepEqual(apple, { available: true, version: '2.50.1' })
+
+  // The suffix must never leak into the reported version.
+  assert.equal(apple.version.includes('Apple'), false)
+})
+
+test('system Git probe keeps accepting the versions Windows and Linux report', async () => {
+  const mingit = await probeSystemGit({ spawn: successfulGitSpawn('2.55.0.windows.5'), timeoutMs: 50 })
+  assert.deepEqual(mingit, { available: true, version: '2.55.0.windows.5' })
+
+  const linux = await probeSystemGit({ spawn: successfulGitSpawn('2.43.0'), timeoutMs: 50 })
+  assert.deepEqual(linux, { available: true, version: '2.43.0' })
+
+  const homebrew = await probeSystemGit({ spawn: successfulGitSpawn('2.51.0'), timeoutMs: 50 })
+  assert.deepEqual(homebrew, { available: true, version: '2.51.0' })
+})
+
+test('system Git probe still rejects output the version suffix must not rescue', async () => {
+  // A malformed version is not made valid by having a suffix after it.
+  const malformed = await probeSystemGit({ spawn: successfulGitSpawn('2.50.1-evil (Apple Git-155)'), timeoutMs: 50 })
+  assert.deepEqual(malformed, { available: false, reason: 'invalid-version-output' })
+
+  // Without separating whitespace the suffix is not a suffix, and the token as
+  // a whole is not a version.
+  const glued = await probeSystemGit({ spawn: successfulGitSpawn('2.50.1(Apple Git-155)'), timeoutMs: 50 })
+  assert.deepEqual(glued, { available: false, reason: 'invalid-version-output' })
+
+  const empty = await probeSystemGit({ spawn: successfulGitSpawn(''), timeoutMs: 50 })
+  assert.deepEqual(empty, { available: false, reason: 'invalid-version-output' })
+})


### PR DESCRIPTION
## 摘要（Summary）

`apps/dsh-desktop/src/managed-git.mjs` 的 `parseGitVersion()` 要求版本号后面**紧跟行尾**：

```
/(?:^|\r?\n)git version ([0-9][0-9A-Za-z.-]{0,79})(?:\r?\n|$)/iu
```

而 Apple 的 git（随 Xcode Command Line Tools 一起装，也就是一台原装 macOS 的 PATH 上实际存在的那个）在同一行输出厂商后缀：

```
git version 2.50.1 (Apple Git-155)
```

这一行匹配不上，于是 `probeSystemGit()` 在**装着可用 git 的机器上**返回 `{ available: false, reason: 'invalid-version-output' }`，`createManagedGitRuntimeService().inspect()` 随之报 `managed-git-unsupported` 而不是 `system-git-available`。

macOS 27.0 / arm64、PATH 上 git 2.50.1 的实测：

| | `probeSystemGit()` | `inspect()` |
|---|---|---|
| 改动前 | `available=false reason=invalid-version-output` | `status=managed-git-unsupported source=unavailable` |
| 改动后 | `available=true version=2.50.1` | `status=system-git-available source=system` |

Windows 的 MinGit 输出 `git version 2.55.0.windows.5`、Linux 输出 `git version 2.43.0`，都没有这个后缀，所以只有 macOS 中招 —— 这也是它一直没被 CI 发现的原因：`desktop-ci.yml` 跑在 windows-latest 上。

改法是让一个以水平空白分隔、有长度上限的后缀被容忍，但**永不返回**。「什么算合法版本号」完全没变：捕获到的 token 仍然要过 `GIT_VERSION_PATTERN`，所以 `2.50.1-evil (Apple Git-155)`（版本号本身非法）与 `2.50.1(Apple Git-155)`（没有分隔空白，整体不是版本号）依旧被拒。要求必须有分隔空白，是为了让一个畸形版本号不可能被"截断成看起来合法的样子"。

## 顺带确认了一件事

原先以为 managed-git 三件套在 macOS 上会撞上 `managed Git release platform must be win32` 之类的硬断言。**实测不会。** 在 darwin 上把 `inspect()` / `repair()` 两条路径都走了一遍（含"系统 git 缺失"这种 `release === null` 最容易崩的情形）：

| 场景 | 结果 |
|---|---|
| `selectManagedGitRelease(darwin/arm64)` | 返回 `null`，不抛 |
| `inspect()`，系统 git 在位 | `system-git-available` / `source=system`，且不往 PATH 里塞任何东西 |
| `inspect()`，系统 git 缺失 | `managed-git-unsupported` / `reason=unsupported-platform` |
| `repair()`，系统 git 缺失 | 同上，**没有**去解引用 `release.id` |
| 四处 `platform must be win32` 断言 | 一次都没触发 |

那几处断言是"永远不会在 darwin 上被构造的对象"的校验器，`selectManagedGitRelease` 先返回 `null` 就把它们全绕开了。所以本 PR 不需要动那部分代码 —— 系统 git 探测这条路本来就是跨平台的，缺的只是版本号解析。

## 涉及包（Affected Packages）

不涉及 `packages/` 下任何包。

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）

其他：`apps/dsh-desktop/src/managed-git.mjs`（一处正则 + 注释）、`apps/dsh-desktop/test/managed-git.test.mjs`（新增 3 个用例）。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git checkout -b macos/system-git-version-probe origin/main
```

基线：`main@33d9d5d`（Merge pull request #45）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Claude Opus 5

使用的编码 Agent 工具：

Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

第 3、5 项说明：本 PR 不新增包目录、不改动任何 README，故不适用。

**未改动任何现有测试用例**，只新增 3 个。

## 本地验证（Local Validation）

执行的命令：

```bash
node --test apps/dsh-desktop/test/managed-git.test.mjs apps/dsh-desktop/test/managed-git-runtime-service.test.mjs
pnpm --filter @deepseek-ai/dsh-desktop test
pnpm typecheck
pnpm test:scripts
pnpm dsh-imports:check
pnpm dsh-audit:check
pnpm runtime-deps:check
pnpm docs:check
pnpm aggregate:check
git diff --check
```

结果摘要：

- 两个 managed-git 测试文件：`tests 20 / pass 19 / fail 1`。新增的 3 个全部通过；唯一失败的 `managed Git PATH helper is immutable, priority-first, and Windows-case-insensitive` 是既有用例，在未改动的上游代码上同样失败（夹具断言 PATH 用 `;` 拼接、路径带反斜杠）。
- 桌面全套：`tests 696 / pass 673 / fail 13 / skipped 10`，13 个失败全部是既有的、夹具级 Windows 假设，与本 PR 无关。
- 端到端：用一个直接构造 `createManagedGitRuntimeService({ platform: 'darwin' })` 的探测脚本核对了上面那两张表里的每一格。
- `pnpm typecheck` / `test:scripts` / `dsh-imports:check` / `dsh-audit:check` / `runtime-deps:check` / `docs:check` / `aggregate:check` 全部通过；`git diff --check` 无空白错误。

关于 `dsh-audit:check`：本 PR 不需要重新生成 DSH 耦合审计 —— 审计产物里 `managed-git.mjs` 的 seam 与 import 记录都是 **0 条**，所以改这个文件不会让审计过期。（这一点是查过产物内容确认的，不是假设。）在纯 `origin/main` 上该检查会因为 lockfile 哈希失同步而失败，那是 #50 修的既有问题，与本 PR 无关。

验证环境：Apple Silicon Mac，macOS 27.0，arm64，Node 24.19.0，pnpm 11.22.0，系统 git 2.50.1（Apple Git-155）。Windows 侧行为未在本地复跑，交由本仓 CI 的 windows-latest 验证 —— MinGit 版本串的不变性由新增用例在任一平台上断言。

## 还剩一块，没放进本 PR

系统 git **确实缺失**时（比如一台没装 Xcode Command Line Tools 的新 Mac），macOS 上的修复界面目前给不出可操作的下一步：`external-tool-missing` 这个分类的动作表里有 `install-managed-git`，但它在 macOS 上会被 `managedGitInstallAvailable` 正确地过滤掉（`electron-app.mjs:1209`），而 macOS 上真正的解法 `xcode-select --install` 没有对应的动作项。

那属于新增一个面向用户的修复动作（要动 `REPAIR_ACTION_IDS`、渲染层文案、IPC 通道），按本仓规则得先经你同意、也要附截图证据，所以不塞进这个纯粹的解析修复里。需要的话我另开一个。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（版本号解析修复，无界面变更；行为证据是上面那两张探测结果对照表）
