### PR TITLE
fix(desktop): prune packaged natives for the target platform

### DIFF
--- a/apps/dsh-desktop/scripts/after-pack.cjs
+++ b/apps/dsh-desktop/scripts/after-pack.cjs
@@ -50,6 +50,15 @@ const RETIRED_SKIN_CARRIER_ASSETS = ['@linxin666', 'dsh-skins', 'skins']
 const SKIN_CENTER_ROOT = ['@linxin666', 'dsh-client-ui-skin-center', 'skins']
 const SKIN_PREVIEW_BOUNDS = Object.freeze({ width: 1440, height: 900 })
 
+const DEFAULT_PACKING_TARGET = Object.freeze({ platform: 'win32', arch: 'x64' })
+const ELECTRON_BUILDER_ARCH_NAMES = Object.freeze({
+  0: 'ia32',
+  1: 'x64',
+  2: 'armv7l',
+  3: 'arm64',
+  4: 'universal',
+})
+
 function splitPackagePath(relativePath) {
   const parts = relativePath.split(/[\\/]/u)
   if (parts[0]?.startsWith('@')) {
@@ -58,7 +67,61 @@ function splitPackagePath(relativePath) {
   return { packageName: parts[0], packageParts: parts.slice(1) }
 }
 
-function classifyPrunableFile(relativePath) {
+function normalizePackingTarget(target = DEFAULT_PACKING_TARGET) {
+  const platform = typeof target?.platform === 'string' && target.platform.length > 0
+    ? target.platform
+    : DEFAULT_PACKING_TARGET.platform
+  const arch = typeof target?.arch === 'string' && target.arch.length > 0
+    ? target.arch
+    : DEFAULT_PACKING_TARGET.arch
+  return { platform, arch }
+}
+
+function packingTargetFromContext(context = {}) {
+  const rawArch = context.arch
+  const arch = typeof rawArch === 'string'
+    ? rawArch
+    : (ELECTRON_BUILDER_ARCH_NAMES[rawArch] ?? DEFAULT_PACKING_TARGET.arch)
+  return normalizePackingTarget({
+    platform: context.electronPlatformName,
+    arch,
+  })
+}
+
+function packagedNodeModulesRoot(context = {}) {
+  const appOutDir = context.appOutDir
+  const platform = context.electronPlatformName
+  if (platform === 'darwin' || platform === 'mas') {
+    const productFilename = context.packager?.appInfo?.productFilename
+      || 'DeepSeek Harness Desktop'
+    return join(
+      appOutDir,
+      `${productFilename}.app`,
+      'Contents',
+      'Resources',
+      'app.asar.unpacked',
+      'node_modules',
+    )
+  }
+  return join(appOutDir, 'resources', 'app.asar.unpacked', 'node_modules')
+}
+
+function isForeignNodePtyBinary(packagePath, { platform, arch }) {
+  // Keep the historical Windows x64 rule byte-for-byte: only darwin-* and
+  // win32-arm64 prebuilds plus the win10-arm64 ConPTY tree are foreign.
+  if (platform === 'win32' && arch === 'x64') {
+    if (/^prebuilds\/(?:darwin-|win32-arm64)/u.test(packagePath)) return true
+    if (/^third_party\/conpty\/[^/]+\/win10-arm64\//u.test(packagePath)) return true
+    return false
+  }
+  const prebuild = /^prebuilds\/([^/]+)\//u.exec(packagePath)
+  if (prebuild) return prebuild[1] !== `${platform}-${arch}`
+  if (/^third_party\/conpty\//u.test(packagePath)) return platform !== 'win32'
+  return false
+}
+
+function classifyPrunableFile(relativePath, target = DEFAULT_PACKING_TARGET) {
+  const packingTarget = normalizePackingTarget(target)
   const normalized = relativePath.replaceAll('\\', '/')
   const { packageName, packageParts } = splitPackagePath(normalized)
   const fileName = packageParts.at(-1) ?? ''
@@ -80,8 +143,7 @@ function classifyPrunableFile(relativePath) {
 
   if (packageName === 'node-pty') {
     const packagePath = packageParts.join('/')
-    if (/^prebuilds\/(?:darwin-|win32-arm64)/u.test(packagePath)) return 'foreign-native-binary'
-    if (/^third_party\/conpty\/[^/]+\/win10-arm64\//u.test(packagePath)) return 'foreign-native-binary'
+    if (isForeignNodePtyBinary(packagePath, packingTarget)) return 'foreign-native-binary'
   }
 
   if (packageName === 'pnpm') {
@@ -266,7 +328,7 @@ async function prunePackagedRuntime(nodeModulesRoot, target = { platform: 'win32
 
   for (const path of files) {
     const relativePath = relative(nodeModulesRoot, path)
-    const category = classifyPrunableFile(relativePath)
+    const category = classifyPrunableFile(relativePath, target)
     if (category === undefined) continue
     const metadata = await stat(path)
     await rm(path, { force: true })
@@ -300,15 +362,12 @@ async function restoreRequiredPackagedPeers(nodeModulesRoot) {
 }
 
 async function afterPack(context) {
-  if (context.electronPlatformName !== 'win32') return
-  const nodeModulesRoot = join(
-    context.appOutDir,
-    'resources',
-    'app.asar.unpacked',
-    'node_modules',
-  )
+  const platform = context.electronPlatformName
+  if (platform !== 'win32' && platform !== 'darwin') return
+  const target = packingTargetFromContext(context)
+  const nodeModulesRoot = packagedNodeModulesRoot(context)
   const restoredPeers = await restoreRequiredPackagedPeers(nodeModulesRoot)
-  const report = await prunePackagedRuntime(nodeModulesRoot)
+  const report = await prunePackagedRuntime(nodeModulesRoot, target)
   report.restoredPeers = restoredPeers
   const outputPath = join(context.outDir, 'runtime-prune-report.json')
   await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`)
@@ -322,3 +381,6 @@ module.exports.classifyPrunableFile = classifyPrunableFile
 module.exports.packageSupportsPlatform = packageSupportsPlatform
 module.exports.prunePackagedRuntime = prunePackagedRuntime
 module.exports.restoreRequiredPackagedPeers = restoreRequiredPackagedPeers
+module.exports.packingTargetFromContext = packingTargetFromContext
+module.exports.packagedNodeModulesRoot = packagedNodeModulesRoot
+module.exports.DEFAULT_PACKING_TARGET = DEFAULT_PACKING_TARGET

--- a/apps/dsh-desktop/test/after-pack-darwin.test.mjs
+++ b/apps/dsh-desktop/test/after-pack-darwin.test.mjs
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict'
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+
+import afterPack from '../scripts/after-pack.cjs'
+
+const {
+  classifyPrunableFile,
+  packingTargetFromContext,
+  packagedNodeModulesRoot,
+  prunePackagedRuntime,
+} = afterPack
+
+const DARWIN_ARM64 = Object.freeze({ platform: 'darwin', arch: 'arm64' })
+
+test('darwin-arm64 packing keeps node-pty spawn-helper and prunes foreign prebuilds', () => {
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/darwin-arm64/pty.node', DARWIN_ARM64),
+    undefined,
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/darwin-arm64/spawn-helper', DARWIN_ARM64),
+    undefined,
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/darwin-x64/pty.node', DARWIN_ARM64),
+    'foreign-native-binary',
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/win32-x64/pty.node', DARWIN_ARM64),
+    'foreign-native-binary',
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/linux-arm64/pty.node', DARWIN_ARM64),
+    'foreign-native-binary',
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/third_party/conpty/win10-x64/conpty.dll', DARWIN_ARM64),
+    'foreign-native-binary',
+  )
+})
+
+test('default classifyPrunableFile still treats darwin prebuilds as foreign on Windows x64', () => {
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/darwin-arm64/pty.node'),
+    'foreign-native-binary',
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/darwin-arm64/spawn-helper'),
+    'foreign-native-binary',
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/win32-x64/pty.node'),
+    undefined,
+  )
+  assert.equal(
+    classifyPrunableFile('node-pty/prebuilds/win32-arm64/pty.node'),
+    'foreign-native-binary',
+  )
+})
+
+test('electron-builder Arch enum 3 maps to darwin arm64', () => {
+  assert.deepEqual(
+    packingTargetFromContext({ electronPlatformName: 'darwin', arch: 3 }),
+    DARWIN_ARM64,
+  )
+  assert.deepEqual(
+    packingTargetFromContext({ electronPlatformName: 'darwin', arch: 'arm64' }),
+    DARWIN_ARM64,
+  )
+  assert.deepEqual(
+    packingTargetFromContext({ electronPlatformName: 'win32', arch: 1 }),
+    { platform: 'win32', arch: 'x64' },
+  )
+})
+
+test('packaged node_modules root uses Contents/Resources on macOS and resources on Windows', () => {
+  assert.equal(
+    packagedNodeModulesRoot({
+      electronPlatformName: 'darwin',
+      appOutDir: '/tmp/mac',
+      packager: { appInfo: { productFilename: 'DeepSeek Harness Desktop' } },
+    }),
+    join(
+      '/tmp/mac',
+      'DeepSeek Harness Desktop.app',
+      'Contents',
+      'Resources',
+      'app.asar.unpacked',
+      'node_modules',
+    ),
+  )
+  assert.equal(
+    packagedNodeModulesRoot({
+      electronPlatformName: 'win32',
+      appOutDir: '/tmp/win-unpacked',
+    }),
+    join('/tmp/win-unpacked', 'resources', 'app.asar.unpacked', 'node_modules'),
+  )
+})
+
+test('darwin-arm64 pruner keeps spawn-helper and drops foreign node-pty prebuilds', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-runtime-prune-darwin-'))
+  try {
+    const fixtures = new Map([
+      ['node-pty/prebuilds/darwin-arm64/pty.node', 'keep-pty'],
+      ['node-pty/prebuilds/darwin-arm64/spawn-helper', 'keep-helper'],
+      ['node-pty/prebuilds/darwin-x64/pty.node', 'drop-x64'],
+      ['node-pty/prebuilds/win32-x64/pty.node', 'drop-win'],
+      ['node-pty/prebuilds/linux-arm64/pty.node', 'drop-linux'],
+      ['openai/index.js', 'runtime'],
+    ])
+    for (const [path, content] of fixtures) {
+      const absolute = join(root, ...path.split('/'))
+      await mkdir(dirname(absolute), { recursive: true })
+      await writeFile(absolute, content)
+    }
+
+    const report = await prunePackagedRuntime(root, DARWIN_ARM64)
+    assert.equal(report.categories['foreign-native-binary'], 3)
+    assert.equal(
+      await readFile(join(root, 'node-pty', 'prebuilds', 'darwin-arm64', 'pty.node'), 'utf8'),
+      'keep-pty',
+    )
+    assert.equal(
+      await readFile(join(root, 'node-pty', 'prebuilds', 'darwin-arm64', 'spawn-helper'), 'utf8'),
+      'keep-helper',
+    )
+    await assert.rejects(
+      readFile(join(root, 'node-pty', 'prebuilds', 'darwin-x64', 'pty.node')),
+      { code: 'ENOENT' },
+    )
+    await assert.rejects(
+      readFile(join(root, 'node-pty', 'prebuilds', 'win32-x64', 'pty.node')),
+      { code: 'ENOENT' },
+    )
+    assert.equal(await readFile(join(root, 'openai', 'index.js'), 'utf8'), 'runtime')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('afterPack on darwin writes a prune report using the macOS bundle layout', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-after-pack-darwin-'))
+  try {
+    const appOutDir = join(root, 'mac')
+    const nodeModules = packagedNodeModulesRoot({
+      electronPlatformName: 'darwin',
+      appOutDir,
+      packager: { appInfo: { productFilename: 'DeepSeek Harness Desktop' } },
+    })
+    const keepPty = join(nodeModules, 'node-pty', 'prebuilds', 'darwin-arm64', 'pty.node')
+    const keepHelper = join(nodeModules, 'node-pty', 'prebuilds', 'darwin-arm64', 'spawn-helper')
+    const dropWin = join(nodeModules, 'node-pty', 'prebuilds', 'win32-x64', 'pty.node')
+    for (const path of [keepPty, keepHelper, dropWin]) {
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, 'native')
+    }
+
+    await afterPack({
+      electronPlatformName: 'darwin',
+      arch: 3,
+      appOutDir,
+      outDir: root,
+      packager: { appInfo: { productFilename: 'DeepSeek Harness Desktop' } },
+    })
+
+    const report = JSON.parse(await readFile(join(root, 'runtime-prune-report.json'), 'utf8'))
+    assert.ok(report.removedFiles >= 1)
+    await access(keepPty)
+    await access(keepHelper)
+    await assert.rejects(access(dropWin), { code: 'ENOENT' })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('afterPack still no-ops on linux so Windows-only early return is not inverted', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-after-pack-linux-'))
+  try {
+    await afterPack({
+      electronPlatformName: 'linux',
+      arch: 'x64',
+      appOutDir: join(root, 'linux-unpacked'),
+      outDir: root,
+    })
+    await assert.rejects(access(join(root, 'runtime-prune-report.json')), { code: 'ENOENT' })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 macOS 打包时 after-pack 直接跳过、并把 `node-pty` 的 darwin 预编译（含 `spawn-helper`）当外来二进制删掉的问题。裁剪改为跟随打包目标平台：darwin-arm64 保留本平台 native，Windows x64 的原有规则保持不变。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：`apps/dsh-desktop` 打包钩子

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin
git checkout -b macos/after-pack-darwin origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Grok 4.6

使用的编码 Agent 工具：Grok

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未修改 README）。

## 贡献者版权声明（Contributor Copyright）

N/A。本 PR 未贡献插件或皮肤。

## 社区插件索引登记（Community Plugin Index）

N/A。本 PR 未新增第三方插件。

## 本地验证（Local Validation）

执行的命令：

```bash
node --test test/after-pack.test.mjs test/after-pack-darwin.test.mjs
git diff --check
node scripts/check-emoji.mjs
```

结果摘要：

- 现有 after-pack 用例 8/8 通过，未改动任何既有断言。
- 新增 darwin 用例 7/7 通过：保留 darwin-arm64 的 pty.node 与 spawn-helper，删除 darwin-x64 / win32 / linux 预编译；mac bundle 走 Contents/Resources；linux 仍早退。
- 合计 tests 15 / pass 15 / fail 0。
- git diff --check 与 emoji 扫描通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A。本 PR 只改打包钩子与单测，不改变已安装 Windows 应用的运行时行为。
