### PR TITLE
fix: remove emoji from desktop workspace

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 [中文](README.md) | English
 
-> ❤️ **Support ongoing development**: If DeepSeek Harness Desktop helps you, consider [supporting the project on Afdian](https://www.ifdian.net/a/ningbai). Your support helps fund servers, testing, and continued maintenance.
+> **Support ongoing development**: If DeepSeek Harness Desktop helps you, consider [supporting the project on Afdian](https://www.ifdian.net/a/ningbai). Your support helps fund servers, testing, and continued maintenance.
 >
 > Scan to support the project:
 >

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 中文 | [English](README.en.md)
 
-> ❤️ **支持项目持续开发**：如果 DeepSeek Harness Desktop 对你有帮助，欢迎在[爱发电支持作者](https://www.ifdian.net/a/ningbai)。你的支持将用于服务器、测试环境和后续维护。
+> **支持项目持续开发**：如果 DeepSeek Harness Desktop 对你有帮助，欢迎在[爱发电支持作者](https://www.ifdian.net/a/ningbai)。你的支持将用于服务器、测试环境和后续维护。
 >
 > 扫码支持：
 >

--- a/packages/dsh-memory/src/client/MemorySettingsCard.tsx
+++ b/packages/dsh-memory/src/client/MemorySettingsCard.tsx
@@ -347,7 +347,7 @@ export function MemorySettingsCard(props: MemorySettingsCardProps) {
           {visibleItems.map(item => (
             <button type="button" role="listitem" key={item.id} className={item.id === selectedId ? styles.itemSelected : styles.item} onClick={() => select(item)}>
               <span className={styles.itemContent}>{item.content}</span>
-              <span className={styles.itemMeta}>{item.scope === 'global' ? t('settings.global') : item.scope === 'workspace' ? t('settings.workspace') : t('settings.session')}{item.pinned ? ' · ★' : ''}</span>
+              <span className={styles.itemMeta}>{item.scope === 'global' ? t('settings.global') : item.scope === 'workspace' ? t('settings.workspace') : t('settings.session')}{item.pinned ? ` · ${t('settings.pinned')}` : ''}</span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
## 摘要（Summary）

移除根目录中英文 README 中触发禁止 emoji CI 的字符，并将记忆设置卡片中的星号置顶标记改为已本地化的“置顶”文本。补充分支基于最新 `main`，相对主分支仅包含这 3 行修复。

## 涉及包（Affected Packages）

- [x] 其他（`packages/dsh-memory` 与根目录 README）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

`git fetch desktop main`

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

GPT-5

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改包 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @ningbainb/dsh-memory typecheck
pnpm --filter @ningbainb/dsh-memory test
pnpm verify
```

结果摘要：

全部通过。`dsh-memory` 定向类型检查通过，6 个测试文件共 18 个测试通过；整仓 typecheck、workspace tests、脚本测试及全部质量门禁通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A。本 PR 仅修复 CI 字符规范与置顶文本显示，不新增功能。